### PR TITLE
feat: add husky and lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+  npm run hooks:debugger-checker && \
+    npm run lint-staged && \
+    npm run format:fix

--- a/hooks/debugger-checker.js
+++ b/hooks/debugger-checker.js
@@ -1,0 +1,73 @@
+const { execSync } = require('child_process');
+const { resolve } = require('path');
+const { readFileSync } = require('fs');
+
+function getStagedFiles() {
+  return execSync('git diff --cached --name-only --diff-filter=ACM', {
+    encoding: 'utf-8',
+  })
+    .trim()
+    .split('\n');
+}
+
+function hasDebugger(line) {
+  const regex = /\bdebugger\b/g;
+  // Returns true if debugger statement is inside string or comment
+  const isCommentOrString = (line) =>
+    line.trim().startsWith('//') ||
+    line.trim().startsWith('/*') ||
+    line.trim().endsWith('*/') ||
+    /(["']).*?[^\\]\1/.test(line);
+
+  return !isCommentOrString(line) && regex.test(line);
+}
+
+function hasDebuggerStatement(file) {
+  const fileContent = readFileSync(resolve(process.cwd(), file), {
+    encoding: 'utf-8',
+  });
+  const lines = fileContent.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+
+    if (
+      line.startsWith('//') ||
+      line.startsWith('/*') ||
+      line.startsWith('*') ||
+      line.endsWith('*/')
+    ) {
+      continue;
+    }
+
+    if (hasDebugger(line)) {
+      return { file, line: i + 1 };
+    }
+  }
+
+  return null;
+}
+
+function checkForDebuggerStatements() {
+  const files = getStagedFiles();
+  const jsFiles = files.filter((file) => /\.(mjs|[jt]s)$/.test(file));
+
+  if (jsFiles.length <= 0) {
+    return;
+  }
+
+  const errors = jsFiles
+    .map((file) => hasDebuggerStatement(file))
+    .filter((result) => result !== null);
+
+  if (errors.length > 0) {
+    errors.forEach((error) =>
+      console.error(
+        `Error: ${error.file}:${error.line} contains a 'debugger' statement`
+      )
+    );
+    process.exit(1);
+  }
+}
+
+checkForDebuggerStatements();

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,0 +1,9 @@
+export default {
+  '**/*.{ts,js,tsx,jsx,mjs,json,md,mdx,scss,html,yml}': (f) =>
+    `npx nx format:write --files=${f.join(',')}`,
+  '{apps,libs}/**/jest.config.ts': (files) =>
+    `node ./scripts/validate-jest-configs.mjs --files=${files.join(',')}`,
+  '{apps,libs,tools}/**/*.{ts,tsx,js,jsx}': 'eslint',
+  '{apps,libs,tools}/**/*.{css,scss}': 'stylelint --fix',
+  '{apps,libs,tools}/**/*.ts': 'npm run lint:with-type-checker --',
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "start": "npx nx run blog:serve",
     "start:storybook": "nx storybook storybook",
     "format:check": " prettier --config ./.prettierrc --check . ",
-    "format:fix": " prettier --config ./.prettierrc --write . "
+    "format:fix": " prettier --config ./.prettierrc --write . ",
+    "prepare": "husky install",
+    "hooks:debugger-checker": "node hooks/debugger-checker.js",
+    "lint-staged": "lint-staged"
   },
   "private": true,
   "dependencies": {
@@ -25,6 +28,7 @@
     "@nguniversal/express-engine": "~16.2.0",
     "@nx/angular": "17.0.2",
     "express": "^4.18.2",
+    "lint-staged": "^15.0.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rxjs": "~7.8.0",
@@ -64,6 +68,7 @@
     "esbuild": "^0.19.2",
     "eslint": "~8.46.0",
     "eslint-config-prettier": "^9.0.0",
+    "husky": "^8.0.0",
     "jest": "^29.4.1",
     "jest-environment-jsdom": "^29.4.1",
     "jest-preset-angular": "~13.1.0",
@@ -74,6 +79,7 @@
     "tailwindcss": "^3.0.2",
     "ts-jest": "^29.1.0",
     "ts-node": "10.9.1",
-    "typescript": "~5.1.3"
+    "typescript": "~5.1.3",
+    "lint-staged": "15.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,10 +46,13 @@ dependencies:
     version: 16.2.0(@angular/common@16.2.0)(@angular/core@16.2.0)(express@4.18.2)
   '@nx/angular':
     specifier: 17.0.2
-    version: 17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3)
+    version: 17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3)
   express:
     specifier: ^4.18.2
     version: 4.18.2
+  lint-staged:
+    specifier: ^15.0.2
+    version: 15.0.2
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -69,7 +72,7 @@ dependencies:
 devDependencies:
   '@angular-devkit/build-angular':
     specifier: ~16.2.0
-    version: 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@16.11.7)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
+    version: 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@18.7.1)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
   '@angular-devkit/core':
     specifier: ~16.2.0
     version: 16.2.0
@@ -97,21 +100,24 @@ devDependencies:
   '@nguniversal/builders':
     specifier: ~16.2.0
     version: 16.2.0(@angular-devkit/build-angular@16.2.9)(@angular/common@16.2.0)(@angular/core@16.2.0)(@types/express@4.17.20)(typescript@5.1.3)
+  '@nx/esbuild':
+    specifier: 17.0.2
+    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3)
   '@nx/eslint':
     specifier: 17.0.2
-    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)
+    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)
   '@nx/eslint-plugin':
     specifier: 17.0.2
-    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
   '@nx/jest':
     specifier: 17.0.2
-    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
+    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
   '@nx/js':
     specifier: 17.0.2
-    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
   '@nx/storybook':
     specifier: ^17.0.2
-    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+    version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
   '@nx/workspace':
     specifier: 17.0.2
     version: 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)
@@ -123,7 +129,7 @@ devDependencies:
     version: 7.5.2(react-dom@18.2.0)(react@18.2.0)
   '@storybook/angular':
     specifier: ^7.5.1
-    version: 7.5.2(@angular-devkit/architect@0.1602.9)(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular/cli@16.2.0)(@angular/common@16.2.0)(@angular/compiler-cli@16.2.11)(@angular/compiler@16.2.11)(@angular/core@16.2.0)(@angular/forms@16.2.0)(@angular/platform-browser-dynamic@16.2.0)(@angular/platform-browser@16.2.0)(@babel/core@7.23.2)(@swc/core@1.3.85)(esbuild@0.18.17)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.1.3)(zone.js@0.13.0)
+    version: 7.5.2(@angular-devkit/architect@0.1602.9)(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular/cli@16.2.0)(@angular/common@16.2.0)(@angular/compiler-cli@16.2.11)(@angular/compiler@16.2.11)(@angular/core@16.2.0)(@angular/forms@16.2.0)(@angular/platform-browser-dynamic@16.2.0)(@angular/platform-browser@16.2.0)(@babel/core@7.23.2)(@swc/core@1.3.85)(esbuild@0.19.5)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.1.3)(zone.js@0.13.0)
   '@storybook/core-server':
     specifier: ^7.5.1
     version: 7.5.2
@@ -140,8 +146,8 @@ devDependencies:
     specifier: ^29.4.0
     version: 29.4.0
   '@types/node':
-    specifier: 16.11.7
-    version: 16.11.7
+    specifier: 18.7.1
+    version: 18.7.1
   '@typescript-eslint/eslint-plugin':
     specifier: ^5.60.1
     version: 5.60.1(@typescript-eslint/parser@5.60.1)(eslint@8.46.0)(typescript@5.1.3)
@@ -151,15 +157,21 @@ devDependencies:
   autoprefixer:
     specifier: ^10.4.0
     version: 10.4.14(postcss@8.4.31)
+  esbuild:
+    specifier: ^0.19.2
+    version: 0.19.5
   eslint:
     specifier: ~8.46.0
     version: 8.46.0
   eslint-config-prettier:
     specifier: ^9.0.0
     version: 9.0.0(eslint@8.46.0)
+  husky:
+    specifier: ^8.0.0
+    version: 8.0.3
   jest:
     specifier: ^29.4.1
-    version: 29.4.1(@types/node@16.11.7)(ts-node@10.9.1)
+    version: 29.4.1(@types/node@18.7.1)(ts-node@10.9.1)
   jest-environment-jsdom:
     specifier: ^29.4.1
     version: 29.4.1
@@ -183,10 +195,10 @@ devDependencies:
     version: 3.0.2(autoprefixer@10.4.14)(postcss@8.4.31)(ts-node@10.9.1)
   ts-jest:
     specifier: ^29.1.0
-    version: 29.1.0(@babel/core@7.23.2)(esbuild@0.18.17)(jest@29.4.1)(typescript@5.1.3)
+    version: 29.1.0(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.4.1)(typescript@5.1.3)
   ts-node:
     specifier: 10.9.1
-    version: 10.9.1(@swc/core@1.3.85)(@types/node@16.11.7)(typescript@5.1.3)
+    version: 10.9.1(@swc/core@1.3.85)(@types/node@18.7.1)(typescript@5.1.3)
   typescript:
     specifier: ~5.1.3
     version: 5.1.3
@@ -250,7 +262,7 @@ packages:
     transitivePeerDependencies:
       - chokidar
 
-  /@angular-devkit/build-angular@16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@16.11.7)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3):
+  /@angular-devkit/build-angular@16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@18.7.1)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-S1C4UYxRVyNt3C0wCxbT2jZ1dN5i37kS0mol3PQjbR8gQ0GQzHmzhjTBl1oImo8aouET9yhrk9etk65oat4mBQ==,
@@ -326,7 +338,7 @@ packages:
       guess-parser: 0.4.22(typescript@5.1.3)
       https-proxy-agent: 5.0.1
       inquirer: 8.2.4
-      jest: 29.4.1(@types/node@16.11.7)(ts-node@10.9.1)
+      jest: 29.4.1(@types/node@18.7.1)(ts-node@10.9.1)
       jest-environment-jsdom: 29.4.1
       jsonc-parser: 3.2.0
       karma-source-map-support: 1.4.0
@@ -357,7 +369,7 @@ packages:
       tree-kill: 1.2.2
       tslib: 2.6.1
       typescript: 5.1.3
-      vite: 4.4.7(@types/node@16.11.7)(less@4.1.3)(sass@1.64.1)(stylus@0.59.0)(terser@5.19.2)
+      vite: 4.4.7(@types/node@18.7.1)(less@4.1.3)(sass@1.64.1)(stylus@0.59.0)(terser@5.19.2)
       webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.17)
       webpack-dev-middleware: 6.1.1(webpack@5.88.2)
       webpack-dev-server: 4.15.1(webpack@5.89.0)
@@ -3622,10 +3634,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-arm64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-5d1OkoJxnYQfmC+Zd8NBFjkhyCNYwM4n9ODrycTFY6Jk1IGiZ+tjVJDDSwDt77nK+tfpGP4T50iMtVi4dEGzhQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/android-arm@0.18.17:
     resolution:
       {
         integrity: sha512-wHsmJG/dnL3OkpAcwbgoBTTMHVi4Uyou3F5mf58ZtmUyIKfcdA7TROav/6tCzET4A3QW2Q2FC+eFneMU+iyOxg==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/android-arm@0.19.5:
+    resolution:
+      {
+        integrity: sha512-bhvbzWFF3CwMs5tbjf3ObfGqbl/17ict2/uwOSfr3wmxDE6VdS2GqY/FuzIPe0q0bdhj65zQsvqfArI9MY6+AA==,
       }
     engines: { node: '>=12' }
     cpu: [arm]
@@ -3644,10 +3678,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/android-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-9t+28jHGL7uBdkBjL90QFxe7DVA+KGqWlHCF8ChTKyaKO//VLuoBricQCgwhOjA1/qOczsw843Fy4cbs4H3DVA==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/darwin-arm64@0.18.17:
     resolution:
       {
         integrity: sha512-M9uJ9VSB1oli2BE/dJs3zVr9kcCBBsE883prage1NWz6pBS++1oNn/7soPNS3+1DGj0FrkSvnED4Bmlu1VAE9g==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-mvXGcKqqIqyKoxq26qEDPHJuBYUA5KizJncKOAf9eJQez+L9O+KfvNFu6nl7SCZ/gFb2QPaRqqmG0doSWlgkqw==,
       }
     engines: { node: '>=12' }
     cpu: [arm64]
@@ -3666,10 +3722,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/darwin-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-Ly8cn6fGLNet19s0X4unjcniX24I0RqjPv+kurpXabZYSXGM4Pwpmf85WHJN3lAgB8GSth7s5A0r856S+4DyiA==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/freebsd-arm64@0.18.17:
     resolution:
       {
         integrity: sha512-cjTzGa3QlNfERa0+ptykyxs5A6FEUQQF0MuilYXYBGdBxD3vxJcKnzDlhDCa1VAJCmAxed6mYhA2KaJIbtiNuQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-GGDNnPWTmWE+DMchq1W8Sd0mUkL+APvJg3b11klSGUDvRXh70JqLAO56tubmq1s2cgpVCSKYywEiKBfju8JztQ==,
       }
     engines: { node: '>=12' }
     cpu: [arm64]
@@ -3688,10 +3766,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/freebsd-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-1CCwDHnSSoA0HNwdfoNY0jLfJpd7ygaLAp5EHFos3VWJCRX9DMwWODf96s9TSse39Br7oOTLryRVmBoFwXbuuQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-arm64@0.18.17:
     resolution:
       {
         integrity: sha512-c9w3tE7qA3CYWjT+M3BMbwMt+0JYOp3vCMKgVBrCl1nwjAlOMYzEo+gG7QaZ9AtqZFj5MbUc885wuBBmu6aADQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-o3vYippBmSrjjQUCEEiTZ2l+4yC0pVJD/Dl57WfPwwlvFkrxoSO7rmBZFii6kQB3Wrn/6GwJUPLU5t52eq2meA==,
       }
     engines: { node: '>=12' }
     cpu: [arm64]
@@ -3710,10 +3810,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-arm@0.19.5:
+    resolution:
+      {
+        integrity: sha512-lrWXLY/vJBzCPC51QN0HM71uWgIEpGSjSZZADQhq7DKhPcI6NH1IdzjfHkDQws2oNpJKpR13kv7/pFHBbDQDwQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-ia32@0.18.17:
     resolution:
       {
         integrity: sha512-1DS9F966pn5pPnqXYz16dQqWIB0dmDfAQZd6jSSpiT9eX1NzKh07J6VKR3AoXXXEk6CqZMojiVDSZi1SlmKVdg==,
+      }
+    engines: { node: '>=12' }
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.19.5:
+    resolution:
+      {
+        integrity: sha512-MkjHXS03AXAkNp1KKkhSKPOCYztRtK+KXDNkBa6P78F8Bw0ynknCSClO/ztGszILZtyO/lVKpa7MolbBZ6oJtQ==,
       }
     engines: { node: '>=12' }
     cpu: [ia32]
@@ -3732,10 +3854,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-loong64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-42GwZMm5oYOD/JHqHska3Jg0r+XFb/fdZRX+WjADm3nLWLcIsN27YKtqxzQmGNJgu0AyXg4HtcSK9HuOk3v1Dw==,
+      }
+    engines: { node: '>=12' }
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-mips64el@0.18.17:
     resolution:
       {
         integrity: sha512-e0bIdHA5p6l+lwqTE36NAW5hHtw2tNRmHlGBygZC14QObsA3bD4C6sXLJjvnDIjSKhW1/0S3eDy+QmX/uZWEYQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.19.5:
+    resolution:
+      {
+        integrity: sha512-kcjndCSMitUuPJobWCnwQ9lLjiLZUR3QLQmlgaBfMX23UEa7ZOrtufnRds+6WZtIS9HdTXqND4yH8NLoVVIkcg==,
       }
     engines: { node: '>=12' }
     cpu: [mips64el]
@@ -3754,10 +3898,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-ppc64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-yJAxJfHVm0ZbsiljbtFFP1BQKLc8kUF6+17tjQ78QjqjAQDnhULWiTA6u0FCDmYT1oOKS9PzZ2z0aBI+Mcyj7Q==,
+      }
+    engines: { node: '>=12' }
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-riscv64@0.18.17:
     resolution:
       {
         integrity: sha512-Wh/HW2MPnC3b8BqRSIme/9Zhab36PPH+3zam5pqGRH4pE+4xTrVLx2+XdGp6fVS3L2x+DrsIcsbMleex8fbE6g==,
+      }
+    engines: { node: '>=12' }
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-5u8cIR/t3gaD6ad3wNt1MNRstAZO+aNyBxu2We8X31bA8XUNyamTVQwLDA1SLoPCUehNCymhBhK3Qim1433Zag==,
       }
     engines: { node: '>=12' }
     cpu: [riscv64]
@@ -3776,10 +3942,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/linux-s390x@0.19.5:
+    resolution:
+      {
+        integrity: sha512-Z6JrMyEw/EmZBD/OFEFpb+gao9xJ59ATsoTNlj39jVBbXqoZm4Xntu6wVmGPB/OATi1uk/DB+yeDPv2E8PqZGw==,
+      }
+    engines: { node: '>=12' }
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/linux-x64@0.18.17:
     resolution:
       {
         integrity: sha512-QM50vJ/y+8I60qEmFxMoxIx4de03pGo2HwxdBeFd4nMh364X6TIBZ6VQ5UQmPbQWUVWHWws5MmJXlHAXvJEmpQ==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/linux-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-psagl+2RlK1z8zWZOmVdImisMtrUxvwereIdyJTmtmHahJTKb64pAcqoPlx6CewPdvGvUKe2Jw+0Z/0qhSbG1A==,
       }
     engines: { node: '>=12' }
     cpu: [x64]
@@ -3798,10 +3986,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/netbsd-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-kL2l+xScnAy/E/3119OggX8SrWyBEcqAh8aOY1gr4gPvw76la2GlD4Ymf832UCVbmuWeTf2adkZDK+h0Z/fB4g==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/openbsd-x64@0.18.17:
     resolution:
       {
         integrity: sha512-rSEeYaGgyGGf4qZM2NonMhMOP/5EHp4u9ehFiBrg7stH6BYEEjlkVREuDEcQ0LfIl53OXLxNbfuIj7mr5m29TA==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-sPOfhtzFufQfTBgRnE1DIJjzsXukKSvZxloZbkJDG383q0awVAq600pc1nfqBcl0ice/WN9p4qLc39WhBShRTA==,
       }
     engines: { node: '>=12' }
     cpu: [x64]
@@ -3820,10 +4030,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/sunos-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-dGZkBXaafuKLpDSjKcB0ax0FL36YXCvJNnztjKV+6CO82tTYVDSH2lifitJ29jxRMoUhgkg9a+VA/B03WK5lcg==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-arm64@0.18.17:
     resolution:
       {
         integrity: sha512-bwPmTJsEQcbZk26oYpc4c/8PvTY3J5/QK8jM19DVlEsAB41M39aWovWoHtNm78sd6ip6prilxeHosPADXtEJFw==,
+      }
+    engines: { node: '>=12' }
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-dWVjD9y03ilhdRQ6Xig1NWNgfLtf2o/STKTS+eZuF90fI2BhbwD6WlaiCGKptlqXlURVB5AUOxUj09LuwKGDTg==,
       }
     engines: { node: '>=12' }
     cpu: [arm64]
@@ -3842,10 +4074,32 @@ packages:
     requiresBuild: true
     optional: true
 
+  /@esbuild/win32-ia32@0.19.5:
+    resolution:
+      {
+        integrity: sha512-4liggWIA4oDgUxqpZwrDhmEfAH4d0iljanDOK7AnVU89T6CzHon/ony8C5LeOdfgx60x5cnQJFZwEydVlYx4iw==,
+      }
+    engines: { node: '>=12' }
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
   /@esbuild/win32-x64@0.18.17:
     resolution:
       {
         integrity: sha512-fGEb8f2BSA3CW7riJVurug65ACLuQAzKq0SSqkY2b2yHHH0MzDfbLyKIGzHwOI/gkHcxM/leuSW6D5w/LMNitA==,
+      }
+    engines: { node: '>=12' }
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.5:
+    resolution:
+      {
+        integrity: sha512-czTrygUsB/jlM8qEW5MD8bgYU2Xg14lo6kBDXW6HdxKjh8M5PzETGiSHaz9MtbXBYDloHNUAUW2tMiKW4KM9Mw==,
       }
     engines: { node: '>=12' }
     cpu: [x64]
@@ -4021,7 +4275,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -4044,14 +4298,14 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@18.7.1)(ts-node@10.9.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4081,7 +4335,7 @@ packages:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       jest-mock: 29.7.0
 
   /@jest/expect-utils@29.7.0:
@@ -4114,7 +4368,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4151,7 +4405,7 @@ packages:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.20
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4251,7 +4505,7 @@ packages:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.5
       '@types/istanbul-reports': 3.0.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       '@types/yargs': 17.0.29
       chalk: 4.1.2
 
@@ -4369,7 +4623,10 @@ packages:
     dev: false
 
   /@ng-icons/tabler-icons@25.6.0:
-    resolution: {integrity: sha512-OIZx6WjUBe551tg8j60+fEJvjU8XFyaXZ7yzcsHs9+aIgxRaMOItmNKqQ0Ncp7mBgryl55YjgmwtJXxkTVNN+Q==}
+    resolution:
+      {
+        integrity: sha512-OIZx6WjUBe551tg8j60+fEJvjU8XFyaXZ7yzcsHs9+aIgxRaMOItmNKqQ0Ncp7mBgryl55YjgmwtJXxkTVNN+Q==,
+      }
     dependencies:
       tslib: 2.6.2
     dev: false
@@ -4404,7 +4661,7 @@ packages:
       '@angular-devkit/build-angular': ^16.0.0 || ^16.1.0-next.0
     dependencies:
       '@angular-devkit/architect': 0.1602.9(chokidar@3.5.3)
-      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@16.11.7)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
+      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@18.7.1)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
       '@angular-devkit/core': 16.2.9(chokidar@3.5.3)
       '@nguniversal/common': 16.2.0(@angular/common@16.2.0)(@angular/core@16.2.0)
       browser-sync: 2.29.3
@@ -4597,13 +4854,13 @@ packages:
       - supports-color
     dev: true
 
-  /@nrwl/angular@17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3):
+  /@nrwl/angular@17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-GheVvG6IiOWfJySLvJY8JMf+O9vaM5KDn4eWaFvT5Vx41UCk1/h36ePlWiOA5Is9wboKCBbijzc9TgW/F3QkiA==,
       }
     dependencies:
-      '@nx/angular': 17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3)
+      '@nx/angular': 17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@angular-devkit/build-angular'
@@ -4644,13 +4901,13 @@ packages:
       - webpack-cli
     dev: false
 
-  /@nrwl/cypress@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
+  /@nrwl/cypress@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-lV3JCBtB7QZXIp3BDmnDbtUDTYt9LHgUePoEG1ohO7D+J71hsx4s8iRo6lOr+HxemlxdBmhSLJlqMTKZv4B1iQ==,
       }
     dependencies:
-      '@nx/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4675,13 +4932,34 @@ packages:
     transitivePeerDependencies:
       - nx
 
-  /@nrwl/eslint-plugin-nx@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
+  /@nrwl/esbuild@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3):
+    resolution:
+      {
+        integrity: sha512-DUrxLcfLYakRBS1eU7WPadcipStmFUOMRxvjQnb1fqUV7eCeQGoR0Pc5WVBYAtl5LVaTLdNgXK7DR0+/D1eHtw==,
+      }
+    dependencies:
+      '@nx/esbuild': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3)
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - debug
+      - esbuild
+      - nx
+      - supports-color
+      - typescript
+      - verdaccio
+    dev: true
+
+  /@nrwl/eslint-plugin-nx@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-kVsyHqaFgWPgCk7C+aimctq1MNnmqQEqCwmB/EC7kPYWPLvF5l7JqlTrDZAmIaCDBKIUUqJsZLO9d46vT5Z9xw==,
       }
     dependencies:
-      '@nx/eslint-plugin': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/eslint-plugin': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4698,13 +4976,13 @@ packages:
       - verdaccio
     dev: true
 
-  /@nrwl/jest@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3):
+  /@nrwl/jest@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-917A/kc3OvwZxi6f5LByp5/j1cByARc7t1yQx+qHW4vl4wtMPcK1Pcl619tLb+DURI/z5Zz9MQvSsdzr4F6ZWg==,
       }
     dependencies:
-      '@nx/jest': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
+      '@nx/jest': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4720,13 +4998,13 @@ packages:
       - typescript
       - verdaccio
 
-  /@nrwl/js@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3):
+  /@nrwl/js@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-qHqZ6V6IP3piyzb9s7HUlcV3X2O/BDmqikg0yoZGitRpyugY5K1BNZITGRmFEzLklfHxVUqI1qsURnClgax+pA==,
       }
     dependencies:
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4739,13 +5017,13 @@ packages:
       - typescript
       - verdaccio
 
-  /@nrwl/storybook@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
+  /@nrwl/storybook@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-vdMIdH0oCNjzNp+LQDaK2cqvRe1Tpti7uCrVin9Jv2aM3+d0oguSO7f99x4nueK0Z7bB1qCvpfXXJVxD6E7Puw==,
       }
     dependencies:
-      '@nx/storybook': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/storybook': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4775,13 +5053,13 @@ packages:
       - '@swc/core'
       - debug
 
-  /@nrwl/web@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3):
+  /@nrwl/web@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-+kSGZ0DOEl6MoWmfCtxcDlmZV/+mqY+pGS+qSB3kZGwfRkpwbv1spAPcYyfUB2wNed9js/lSRGt9sBcwWcIY0Q==,
       }
     dependencies:
-      '@nx/web': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/web': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -4795,13 +5073,13 @@ packages:
       - verdaccio
     dev: false
 
-  /@nrwl/webpack@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(nx@17.0.2)(typescript@5.1.3):
+  /@nrwl/webpack@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-5Kx9drlEGchWDlE8x7uxRIqZEzm8TZll07NUTm++wKWukHhCZZksqojRQkRLq28iO2BFQm12boa78Ku0u3Ob4g==,
       }
     dependencies:
-      '@nx/webpack': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/webpack': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@parcel/css'
@@ -4842,7 +5120,7 @@ packages:
       - '@swc/core'
       - debug
 
-  /@nx/angular@17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3):
+  /@nx/angular@17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-I3C9ImpFYChIVWrXLI2cZy1uiJ6zzoHTDd+y1tuhWF+OWMoeCi/iVKyk4DWucdU2AUlpgfJWRVWqCQcMR32U1Q==,
@@ -4861,25 +5139,25 @@ packages:
       esbuild:
         optional: true
     dependencies:
-      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@16.11.7)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
+      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@18.7.1)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
       '@angular-devkit/core': 16.2.0
       '@angular-devkit/schematics': 16.2.9
       '@nguniversal/builders': 16.2.0(@angular-devkit/build-angular@16.2.9)(@angular/common@16.2.0)(@angular/core@16.2.0)(@types/express@4.17.20)(typescript@5.1.3)
-      '@nrwl/angular': 17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3)
-      '@nx/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/angular': 17.0.2(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular-devkit/schematics@16.2.9)(@nguniversal/builders@16.2.0)(@schematics/angular@16.2.9)(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(eslint@8.46.0)(nx@17.0.2)(rxjs@7.8.1)(ts-node@10.9.1)(typescript@5.1.3)
+      '@nx/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)
-      '@nx/jest': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
-      '@nx/web': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
-      '@nx/webpack': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)
+      '@nx/jest': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/web': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/webpack': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3)
       '@nx/workspace': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.3)
       '@schematics/angular': 16.2.9
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.46.0)(typescript@5.1.3)
       chalk: 4.1.2
       enquirer: 2.4.1
-      esbuild: 0.18.17
+      esbuild: 0.19.5
       find-cache-dir: 3.3.2
       ignore: 5.2.4
       magic-string: 0.30.5
@@ -4887,7 +5165,7 @@ packages:
       rxjs: 7.8.1
       semver: 7.5.3
       tslib: 2.6.2
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - '@babel/traverse'
@@ -4921,7 +5199,7 @@ packages:
       - webpack-cli
     dev: false
 
-  /@nx/cypress@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
+  /@nx/cypress@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-lkdhz6CHaLA/ZhNnqwXBp4Mlg1eTtCO09pYYHMx43D7EPObO1XbYtm6rivWg6kDzEmz84+Jwo0RucK7loMlHqA==,
@@ -4932,10 +5210,10 @@ packages:
       cypress:
         optional: true
     dependencies:
-      '@nrwl/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.3)
       detect-port: 1.5.1
       semver: 7.5.3
@@ -4970,7 +5248,40 @@ packages:
       tmp: 0.2.1
       tslib: 2.6.2
 
-  /@nx/eslint-plugin@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
+  /@nx/esbuild@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3):
+    resolution:
+      {
+        integrity: sha512-mKs2j0PGQy5z8t21Zw56OT1Inrfxcr7oULL5pAuxlbdH+bkPaqaWV3ba3uM5wm4uLMZIsRyMPwcQwXYrcwVSww==,
+      }
+    peerDependencies:
+      esbuild: ~0.19.2
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+    dependencies:
+      '@nrwl/esbuild': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/devkit': 17.0.2(nx@17.0.2)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
+      chalk: 4.1.2
+      esbuild: 0.19.5
+      fast-glob: 3.2.7
+      fs-extra: 11.1.1
+      tsconfig-paths: 4.2.0
+      tslib: 2.6.2
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/core'
+      - '@swc/wasm'
+      - '@types/node'
+      - debug
+      - nx
+      - supports-color
+      - typescript
+      - verdaccio
+    dev: true
+
+  /@nx/eslint-plugin@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-ZI/vthG7wYG9+xA3inYnJ+XP8itMlZpIYT63SZm4h05MRYQG4MkShkrOkSWYBtT2j5b1AgSzSemkpCGuG798pQ==,
@@ -4982,9 +5293,9 @@ packages:
       eslint-config-prettier:
         optional: true
     dependencies:
-      '@nrwl/eslint-plugin-nx': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/eslint-plugin-nx': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(@typescript-eslint/parser@5.60.1)(eslint-config-prettier@9.0.0)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       '@typescript-eslint/parser': 5.60.1(eslint@8.46.0)(typescript@5.1.3)
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.46.0)(typescript@5.1.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.46.0)(typescript@5.1.3)
@@ -5008,7 +5319,7 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/eslint@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2):
+  /@nx/eslint@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2):
     resolution:
       {
         integrity: sha512-mZXavg/m+A0GqmWORq5jNRt7ku0q9OoX2212ldivvLYI1zHHr2VFYoRxhS+NzaZBK5/EiKs/5P8dHhYb4/v7Bw==,
@@ -5020,8 +5331,8 @@ packages:
         optional: true
     dependencies:
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
-      '@nx/linter': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/linter': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)
       eslint: 8.46.0
       tslib: 2.6.2
       typescript: 5.1.3
@@ -5036,7 +5347,7 @@ packages:
       - supports-color
       - verdaccio
 
-  /@nx/jest@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3):
+  /@nx/jest@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-kpkziUOZpKsVvi5iicirX4EVwfKXaGuiv5bgzj1uiexD83tlds5ne8J2qN/K1ea5jIC+bxHzqJF5s7rF52T0cg==,
@@ -5044,13 +5355,13 @@ packages:
     dependencies:
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
-      '@nrwl/jest': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
+      '@nrwl/jest': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(ts-node@10.9.1)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.3)
       chalk: 4.1.2
       identity-obj-proxy: 3.0.0
-      jest-config: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@18.7.1)(ts-node@10.9.1)
       jest-resolve: 29.7.0
       jest-util: 29.7.0
       resolve.exports: 1.1.0
@@ -5070,7 +5381,7 @@ packages:
       - typescript
       - verdaccio
 
-  /@nx/js@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3):
+  /@nx/js@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-dYvWDd0jwNF4h4V8yjd1ZMSJ38GcpvwrDUVYGYNkZmDqYzkBvqykpY00hRLUYZspiR+iG7uWmyxItZYpCk0WyA==,
@@ -5087,7 +5398,7 @@ packages:
       '@babel/preset-env': 7.23.2(@babel/core@7.23.2)
       '@babel/preset-typescript': 7.23.2(@babel/core@7.23.2)
       '@babel/runtime': 7.23.2
-      '@nrwl/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
       '@nx/workspace': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.3)
@@ -5107,7 +5418,7 @@ packages:
       ora: 5.3.0
       semver: 7.5.3
       source-map-support: 0.5.19
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@16.11.7)(typescript@5.1.3)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@18.7.1)(typescript@5.1.3)
       tsconfig-paths: 4.2.0
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -5121,13 +5432,13 @@ packages:
       - supports-color
       - typescript
 
-  /@nx/linter@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2):
+  /@nx/linter@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2):
     resolution:
       {
         integrity: sha512-cXCrx/qcZc53GKqOLRIPTqACdby9/plOpfQlo0BlHMOrwvkkKjzXsnoJgR6XRWdegDKVkqUWHWDAjDI3/aMshA==,
       }
     dependencies:
-      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)
+      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -5250,17 +5561,17 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@nx/storybook@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
+  /@nx/storybook@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-5yr2BEf1TILkp6WFgIBagYiL+sEj7KxRzVUBEL8MCbpJVUCw/lWN+K/PeQvrOBRc/tV8uiP5p+wRq9EJz6IUgg==,
       }
     dependencies:
-      '@nrwl/storybook': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
-      '@nx/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/storybook': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/cypress': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(eslint@8.46.0)(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/eslint': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(eslint@8.46.0)(nx@17.0.2)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.1.3)
       semver: 7.5.3
       tslib: 2.6.2
@@ -5279,15 +5590,15 @@ packages:
       - verdaccio
     dev: true
 
-  /@nx/web@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3):
+  /@nx/web@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-M8bausXzgkeFlNn43uO3pxtn/1EDoIs/7xgWPoGAdqV4l4RKG0JHqeLi68tP6YVA30RSAZ7UmvKQlKo14uDp0w==,
       }
     dependencies:
-      '@nrwl/web': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/web': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       chalk: 4.1.2
       detect-port: 1.5.1
       http-server: 14.1.1
@@ -5305,23 +5616,23 @@ packages:
       - verdaccio
     dev: false
 
-  /@nx/webpack@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(nx@17.0.2)(typescript@5.1.3):
+  /@nx/webpack@17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-TnC+Cpg7MPc6vl1Vu2sVzav/F+6mhmev3tH3nCUFywTwHXrK+i/NQhuvXWEixVt+l77V4Di6VhMKfHaGryfU6Q==,
       }
     dependencies:
       '@babel/core': 7.23.2
-      '@nrwl/webpack': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(esbuild@0.18.17)(nx@17.0.2)(typescript@5.1.3)
+      '@nrwl/webpack': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(esbuild@0.19.5)(nx@17.0.2)(typescript@5.1.3)
       '@nx/devkit': 17.0.2(nx@17.0.2)
-      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@16.11.7)(nx@17.0.2)(typescript@5.1.3)
+      '@nx/js': 17.0.2(@swc-node/register@1.6.7)(@swc/core@1.3.85)(@types/node@18.7.1)(nx@17.0.2)(typescript@5.1.3)
       autoprefixer: 10.4.16(postcss@8.4.31)
       babel-loader: 9.1.3(@babel/core@7.23.2)(webpack@5.89.0)
       browserslist: 4.22.1
       chalk: 4.1.2
       copy-webpack-plugin: 10.2.4(webpack@5.89.0)
       css-loader: 6.8.1(webpack@5.89.0)
-      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.18.17)(webpack@5.89.0)
+      css-minimizer-webpack-plugin: 5.0.1(esbuild@0.19.5)(webpack@5.89.0)
       fork-ts-checker-webpack-plugin: 7.2.13(typescript@5.1.3)(webpack@5.89.0)
       less: 4.1.3
       less-loader: 11.1.0(less@4.1.3)(webpack@5.89.0)
@@ -5339,11 +5650,11 @@ packages:
       style-loader: 3.3.3(webpack@5.89.0)
       stylus: 0.59.0
       stylus-loader: 7.1.3(stylus@0.59.0)(webpack@5.89.0)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.18.17)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.19.5)(webpack@5.89.0)
       ts-loader: 9.5.0(typescript@5.1.3)(webpack@5.89.0)
       tsconfig-paths-webpack-plugin: 4.0.0
       tslib: 2.6.2
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
       webpack-dev-server: 4.15.1(webpack@5.89.0)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(webpack@5.89.0)
@@ -6430,7 +6741,7 @@ packages:
       - '@types/react-dom'
     dev: true
 
-  /@storybook/angular@7.5.2(@angular-devkit/architect@0.1602.9)(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular/cli@16.2.0)(@angular/common@16.2.0)(@angular/compiler-cli@16.2.11)(@angular/compiler@16.2.11)(@angular/core@16.2.0)(@angular/forms@16.2.0)(@angular/platform-browser-dynamic@16.2.0)(@angular/platform-browser@16.2.0)(@babel/core@7.23.2)(@swc/core@1.3.85)(esbuild@0.18.17)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.1.3)(zone.js@0.13.0):
+  /@storybook/angular@7.5.2(@angular-devkit/architect@0.1602.9)(@angular-devkit/build-angular@16.2.9)(@angular-devkit/core@16.2.0)(@angular/cli@16.2.0)(@angular/common@16.2.0)(@angular/compiler-cli@16.2.11)(@angular/compiler@16.2.11)(@angular/core@16.2.0)(@angular/forms@16.2.0)(@angular/platform-browser-dynamic@16.2.0)(@angular/platform-browser@16.2.0)(@babel/core@7.23.2)(@swc/core@1.3.85)(esbuild@0.19.5)(react-dom@18.2.0)(react@18.2.0)(rxjs@7.8.1)(typescript@5.1.3)(zone.js@0.13.0):
     resolution:
       {
         integrity: sha512-ZcRyF4C+chI1yCmILPbN3d/Hbfy04jRzZyq7KK06ODtVZ0Lo0Q5qeZEHIzYlS75G8z2AkPR6zMStVaVyR7wtwA==,
@@ -6459,7 +6770,7 @@ packages:
         optional: true
     dependencies:
       '@angular-devkit/architect': 0.1602.9(chokidar@3.5.3)
-      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@16.11.7)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
+      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@18.7.1)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
       '@angular-devkit/core': 16.2.0
       '@angular/cli': 16.2.0
       '@angular/common': 16.2.0(@angular/core@16.2.0)(rxjs@7.8.1)
@@ -6470,7 +6781,7 @@ packages:
       '@angular/platform-browser': 16.2.0(@angular/animations@16.2.0)(@angular/common@16.2.0)(@angular/core@16.2.0)
       '@angular/platform-browser-dynamic': 16.2.0(@angular/common@16.2.0)(@angular/compiler@16.2.11)(@angular/core@16.2.0)(@angular/platform-browser@16.2.0)
       '@babel/core': 7.23.2
-      '@storybook/builder-webpack5': 7.5.2(esbuild@0.18.17)(typescript@5.1.3)
+      '@storybook/builder-webpack5': 7.5.2(esbuild@0.19.5)(typescript@5.1.3)
       '@storybook/cli': 7.5.2
       '@storybook/client-logger': 7.5.2
       '@storybook/core-common': 7.5.2
@@ -6484,7 +6795,7 @@ packages:
       '@storybook/preview-api': 7.5.2
       '@storybook/telemetry': 7.5.2
       '@storybook/types': 7.5.2
-      '@types/node': 18.18.8
+      '@types/node': 18.7.1
       '@types/react': 16.14.50
       '@types/react-dom': 16.9.21
       '@types/semver': 7.5.4
@@ -6500,7 +6811,7 @@ packages:
       tsconfig-paths-webpack-plugin: 4.1.0
       typescript: 5.1.3
       util-deprecate: 1.0.2
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
       zone.js: 0.13.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -6582,7 +6893,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-webpack5@7.5.2(esbuild@0.18.17)(typescript@5.1.3):
+  /@storybook/builder-webpack5@7.5.2(esbuild@0.19.5)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-eGMbwyw65z1Fmsq6U/rXPjywBCDwtI5ZvV9zendxxeAVNLpzTFioxlRNYsYZqcLEfE6GoNYjIOkn4S9UV0N+VA==,
@@ -6603,7 +6914,7 @@ packages:
       '@storybook/preview': 7.5.2
       '@storybook/preview-api': 7.5.2
       '@swc/core': 1.3.85
-      '@types/node': 18.18.8
+      '@types/node': 18.7.1
       '@types/semver': 7.5.4
       babel-loader: 9.1.3(@babel/core@7.23.2)(webpack@5.89.0)
       babel-plugin-named-exports-order: 0.0.2
@@ -6620,13 +6931,13 @@ packages:
       semver: 7.5.4
       style-loader: 3.3.3(webpack@5.89.0)
       swc-loader: 0.2.3(@swc/core@1.3.85)(webpack@5.89.0)
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.18.17)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.19.5)(webpack@5.89.0)
       ts-dedent: 2.2.0
       typescript: 5.1.3
       url: 0.11.3
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
       webpack-dev-middleware: 6.1.1(webpack@5.89.0)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.5.0
@@ -6777,7 +7088,7 @@ packages:
       '@storybook/node-logger': 7.5.2
       '@storybook/types': 7.5.2
       '@types/find-cache-dir': 3.2.1
-      '@types/node': 18.18.8
+      '@types/node': 18.7.1
       '@types/node-fetch': 2.6.8
       '@types/pretty-hrtime': 1.0.2
       chalk: 4.1.2
@@ -6832,7 +7143,7 @@ packages:
       '@storybook/telemetry': 7.5.2
       '@storybook/types': 7.5.2
       '@types/detect-port': 1.3.4
-      '@types/node': 18.18.8
+      '@types/node': 18.7.1
       '@types/pretty-hrtime': 1.0.2
       '@types/semver': 7.5.4
       better-opn: 3.0.2
@@ -6873,7 +7184,7 @@ packages:
       '@storybook/core-common': 7.5.2
       '@storybook/node-logger': 7.5.2
       '@storybook/types': 7.5.2
-      '@types/node': 18.18.8
+      '@types/node': 18.7.1
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - encoding
@@ -7404,7 +7715,7 @@ packages:
       }
     dependencies:
       '@types/connect': 3.4.37
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/bonjour@3.5.12:
     resolution:
@@ -7412,7 +7723,7 @@ packages:
         integrity: sha512-ky0kWSqXVxSqgqJvPIkgFkcn4C8MnRog308Ou8xBBIVo39OmUFy+jqNe0nPwLCDFxUpmT9EvT91YzOJgkDRcFg==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/connect-history-api-fallback@1.5.2:
     resolution:
@@ -7421,7 +7732,7 @@ packages:
       }
     dependencies:
       '@types/express-serve-static-core': 4.17.39
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/connect@3.4.37:
     resolution:
@@ -7429,7 +7740,7 @@ packages:
         integrity: sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/cookie@0.4.1:
     resolution:
@@ -7443,7 +7754,7 @@ packages:
         integrity: sha512-n91JxbNLD8eQIuXDIChAN1tCKNWCEgpceU9b7ZMbFA+P+Q4yIeh80jizFLEvolRPc1ES0VdwFlGv+kJTSirogw==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/cross-spawn@6.0.4:
     resolution:
@@ -7451,7 +7762,7 @@ packages:
         integrity: sha512-GGLpeThc2Bu8FBGmVn76ZU3lix17qZensEI4/MPty0aZpm2CHfgEMis31pf5X5EiudYKcPAsWciAsCALoPo5dw==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
     dev: true
 
   /@types/detect-port@1.3.4:
@@ -7512,7 +7823,7 @@ packages:
         integrity: sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       '@types/qs': 6.9.9
       '@types/range-parser': 1.2.6
       '@types/send': 0.17.3
@@ -7541,7 +7852,7 @@ packages:
         integrity: sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/html-minifier-terser@6.1.0:
     resolution:
@@ -7562,7 +7873,7 @@ packages:
         integrity: sha512-GkhdWcMNiR5QSQRYnJ+/oXzu0+7JJEPC8vkWXK351BkhjraZF+1W13CUYARUvX9+NqIU2n6YHA4iwywsc/M6Sw==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/istanbul-lib-coverage@2.0.5:
     resolution:
@@ -7602,7 +7913,7 @@ packages:
         integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       '@types/tough-cookie': 4.0.4
       parse5: 7.1.2
 
@@ -7651,7 +7962,7 @@ packages:
         integrity: sha512-nnH5lV9QCMPsbEVdTb5Y+F3GQxLSw1xQgIydrb2gSfEavRPs50FnMr+KUaa+LoPSqibm2N+ZZxH7lavZlAT4GA==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       form-data: 4.0.0
     dev: true
 
@@ -7661,22 +7972,13 @@ packages:
         integrity: sha512-vGXshY9vim9CJjrpcS5raqSjEfKlJcWy2HNdgUasR66fAnVEYarrf1ULV4nfvpC1nZq/moA9qyqBcu83x+Jlrg==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
-  /@types/node@16.11.7:
+  /@types/node@18.7.1:
     resolution:
       {
-        integrity: sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw==,
+        integrity: sha512-GKX1Qnqxo4S+Z/+Z8KKPLpH282LD7jLHWJcVryOflnsnH+BtSDfieR6ObwBMwpnNws0bUK8GI7z0unQf9bARNQ==,
       }
-
-  /@types/node@18.18.8:
-    resolution:
-      {
-        integrity: sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==,
-      }
-    dependencies:
-      undici-types: 5.26.5
-    dev: true
 
   /@types/normalize-package-data@2.4.3:
     resolution:
@@ -7774,7 +8076,7 @@ packages:
       }
     dependencies:
       '@types/mime': 1.3.4
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/serve-index@1.9.3:
     resolution:
@@ -7792,7 +8094,7 @@ packages:
     dependencies:
       '@types/http-errors': 2.0.3
       '@types/mime': 3.0.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/sockjs@0.3.35:
     resolution:
@@ -7800,7 +8102,7 @@ packages:
         integrity: sha512-tIF57KB+ZvOBpAQwSaACfEu7htponHXaFzP7RfKYgsOS0NoYnn+9+jzp7bbq4fWerizI3dTB4NfAZoyeQKWJLw==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/stack-utils@2.0.2:
     resolution:
@@ -7834,7 +8136,7 @@ packages:
         integrity: sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==,
       }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
 
   /@types/yargs-parser@21.0.2:
     resolution:
@@ -8207,7 +8509,7 @@ packages:
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      vite: 4.4.7(@types/node@16.11.7)(less@4.1.3)(sass@1.64.1)(stylus@0.59.0)(terser@5.19.2)
+      vite: 4.4.7(@types/node@18.7.1)(less@4.1.3)(sass@1.64.1)(stylus@0.59.0)(terser@5.19.2)
 
   /@webassemblyjs/ast@1.11.6:
     resolution:
@@ -8680,6 +8982,16 @@ packages:
     dependencies:
       type-fest: 0.21.3
 
+  /ansi-escapes@5.0.0:
+    resolution:
+      {
+        integrity: sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      type-fest: 1.4.0
+    dev: false
+
   /ansi-html-community@0.0.8:
     resolution:
       {
@@ -8701,7 +9013,6 @@ packages:
         integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==,
       }
     engines: { node: '>=12' }
-    dev: true
 
   /ansi-styles@3.2.1:
     resolution:
@@ -8734,7 +9045,6 @@ packages:
         integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==,
       }
     engines: { node: '>=12' }
-    dev: true
 
   /anymatch@3.1.3:
     resolution:
@@ -9055,7 +9365,7 @@ packages:
       '@babel/core': 7.23.2
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
 
   /babel-plugin-const-enum@1.2.0(@babel/core@7.23.2):
     resolution:
@@ -9721,6 +10031,14 @@ packages:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  /chalk@5.3.0:
+    resolution:
+      {
+        integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==,
+      }
+    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
+    dev: false
+
   /char-regex@1.0.2:
     resolution:
       {
@@ -9813,6 +10131,16 @@ packages:
     dependencies:
       restore-cursor: 3.1.0
 
+  /cli-cursor@4.0.0:
+    resolution:
+      {
+        integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      restore-cursor: 4.0.0
+    dev: false
+
   /cli-spinners@2.6.1:
     resolution:
       {
@@ -9838,6 +10166,17 @@ packages:
     optionalDependencies:
       '@colors/colors': 1.5.0
     dev: true
+
+  /cli-truncate@3.1.0:
+    resolution:
+      {
+        integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      slice-ansi: 5.0.0
+      string-width: 5.1.2
+    dev: false
 
   /cli-width@3.0.0:
     resolution:
@@ -9966,6 +10305,14 @@ packages:
     engines: { node: '>= 0.8' }
     dependencies:
       delayed-stream: 1.0.0
+
+  /commander@11.1.0:
+    resolution:
+      {
+        integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==,
+      }
+    engines: { node: '>=16' }
+    dev: false
 
   /commander@2.20.3:
     resolution:
@@ -10174,7 +10521,7 @@ packages:
       normalize-path: 3.0.0
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /copy-webpack-plugin@11.0.0(webpack@5.88.2):
@@ -10270,7 +10617,7 @@ packages:
       path-type: 4.0.0
       typescript: 5.1.3
 
-  /create-jest@29.7.0(@types/node@16.11.7)(ts-node@10.9.1):
+  /create-jest@29.7.0(@types/node@18.7.1)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==,
@@ -10282,7 +10629,7 @@ packages:
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@18.7.1)(ts-node@10.9.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -10378,9 +10725,9 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.31)
       postcss-value-parser: 4.2.0
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
 
-  /css-minimizer-webpack-plugin@5.0.1(esbuild@0.18.17)(webpack@5.89.0):
+  /css-minimizer-webpack-plugin@5.0.1(esbuild@0.19.5)(webpack@5.89.0):
     resolution:
       {
         integrity: sha512-3caImjKFQkS+ws1TGcFn0V1HyDJFq1Euy589JlD6/3rV2kj+w7r5G9WDMgSHvpvXHNZ2calVypZWuEDQd9wfLg==,
@@ -10410,12 +10757,12 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
       cssnano: 6.0.1(postcss@8.4.31)
-      esbuild: 0.18.17
+      esbuild: 0.19.5
       jest-worker: 29.7.0
       postcss: 8.4.31
       schema-utils: 4.2.0
       serialize-javascript: 6.0.1
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /css-select@4.3.0:
@@ -11150,7 +11497,6 @@ packages:
       {
         integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==,
       }
-    dev: true
 
   /easy-extender@2.3.4:
     resolution:
@@ -11210,7 +11556,6 @@ packages:
       {
         integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
       }
-    dev: true
 
   /emojis-list@3.0.0:
     resolution:
@@ -11277,7 +11622,7 @@ packages:
     dependencies:
       '@types/cookie': 0.4.1
       '@types/cors': 2.8.15
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       accepts: 1.3.8
       base64id: 2.0.0
       cookie: 0.4.2
@@ -11460,6 +11805,38 @@ packages:
       '@esbuild/win32-arm64': 0.18.17
       '@esbuild/win32-ia32': 0.18.17
       '@esbuild/win32-x64': 0.18.17
+
+  /esbuild@0.19.5:
+    resolution:
+      {
+        integrity: sha512-bUxalY7b1g8vNhQKdB24QDmHeY4V4tw/s6Ak5z+jJX9laP5MoQseTOMemAr0gxssjNcH0MCViG8ONI2kksvfFQ==,
+      }
+    engines: { node: '>=12' }
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/android-arm': 0.19.5
+      '@esbuild/android-arm64': 0.19.5
+      '@esbuild/android-x64': 0.19.5
+      '@esbuild/darwin-arm64': 0.19.5
+      '@esbuild/darwin-x64': 0.19.5
+      '@esbuild/freebsd-arm64': 0.19.5
+      '@esbuild/freebsd-x64': 0.19.5
+      '@esbuild/linux-arm': 0.19.5
+      '@esbuild/linux-arm64': 0.19.5
+      '@esbuild/linux-ia32': 0.19.5
+      '@esbuild/linux-loong64': 0.19.5
+      '@esbuild/linux-mips64el': 0.19.5
+      '@esbuild/linux-ppc64': 0.19.5
+      '@esbuild/linux-riscv64': 0.19.5
+      '@esbuild/linux-s390x': 0.19.5
+      '@esbuild/linux-x64': 0.19.5
+      '@esbuild/netbsd-x64': 0.19.5
+      '@esbuild/openbsd-x64': 0.19.5
+      '@esbuild/sunos-x64': 0.19.5
+      '@esbuild/win32-arm64': 0.19.5
+      '@esbuild/win32-ia32': 0.19.5
+      '@esbuild/win32-x64': 0.19.5
 
   /escalade@3.1.1:
     resolution:
@@ -11673,6 +12050,13 @@ packages:
         integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==,
       }
 
+  /eventemitter3@5.0.1:
+    resolution:
+      {
+        integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
+      }
+    dev: false
+
   /events@3.3.0:
     resolution:
       {
@@ -11696,6 +12080,24 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
+
+  /execa@8.0.1:
+    resolution:
+      {
+        integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==,
+      }
+    engines: { node: '>=16.17' }
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 8.0.1
+      human-signals: 5.0.0
+      is-stream: 3.0.0
+      merge-stream: 2.0.0
+      npm-run-path: 5.1.0
+      onetime: 6.0.0
+      signal-exit: 4.1.0
+      strip-final-newline: 3.0.0
+    dev: false
 
   /exit@0.1.2:
     resolution:
@@ -12128,7 +12530,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.1.3
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /fork-ts-checker-webpack-plugin@8.0.0(typescript@5.1.3)(webpack@5.89.0):
@@ -12154,7 +12556,7 @@ packages:
       semver: 7.5.4
       tapable: 2.2.1
       typescript: 5.1.3
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: true
 
   /form-data@3.0.1:
@@ -12371,6 +12773,14 @@ packages:
         integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
       }
     engines: { node: '>=10' }
+
+  /get-stream@8.0.1:
+    resolution:
+      {
+        integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==,
+      }
+    engines: { node: '>=16' }
+    dev: false
 
   /giget@1.1.3:
     resolution:
@@ -12810,7 +13220,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: true
 
   /htmlparser2@6.1.0:
@@ -13011,6 +13421,14 @@ packages:
       }
     engines: { node: '>=10.17.0' }
 
+  /human-signals@5.0.0:
+    resolution:
+      {
+        integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==,
+      }
+    engines: { node: '>=16.17.0' }
+    dev: false
+
   /humanize-ms@1.2.1:
     resolution:
       {
@@ -13018,6 +13436,15 @@ packages:
       }
     dependencies:
       ms: 2.1.3
+    dev: true
+
+  /husky@8.0.3:
+    resolution:
+      {
+        integrity: sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==,
+      }
+    engines: { node: '>=14' }
+    hasBin: true
     dev: true
 
   /iconv-lite@0.4.24:
@@ -13361,6 +13788,14 @@ packages:
       }
     engines: { node: '>=8' }
 
+  /is-fullwidth-code-point@4.0.0:
+    resolution:
+      {
+        integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==,
+      }
+    engines: { node: '>=12' }
+    dev: false
+
   /is-generator-fn@2.1.0:
     resolution:
       {
@@ -13522,6 +13957,14 @@ packages:
         integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
       }
     engines: { node: '>=8' }
+
+  /is-stream@3.0.0:
+    resolution:
+      {
+        integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dev: false
 
   /is-string@1.0.7:
     resolution:
@@ -13743,7 +14186,7 @@ packages:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.1
@@ -13763,7 +14206,7 @@ packages:
       - babel-plugin-macros
       - supports-color
 
-  /jest-cli@29.7.0(@types/node@16.11.7)(ts-node@10.9.1):
+  /jest-cli@29.7.0(@types/node@18.7.1)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==,
@@ -13780,10 +14223,10 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
+      create-jest: 29.7.0(@types/node@18.7.1)(ts-node@10.9.1)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
+      jest-config: 29.7.0(@types/node@18.7.1)(ts-node@10.9.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -13793,7 +14236,7 @@ packages:
       - supports-color
       - ts-node
 
-  /jest-config@29.7.0(@types/node@16.11.7)(ts-node@10.9.1):
+  /jest-config@29.7.0(@types/node@18.7.1)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==,
@@ -13811,7 +14254,7 @@ packages:
       '@babel/core': 7.23.2
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       babel-jest: 29.7.0(@babel/core@7.23.2)
       chalk: 4.1.2
       ci-info: 3.9.0
@@ -13831,7 +14274,7 @@ packages:
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@16.11.7)(typescript@5.1.3)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@18.7.1)(typescript@5.1.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -13886,7 +14329,7 @@ packages:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3
@@ -13905,7 +14348,7 @@ packages:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -13925,7 +14368,7 @@ packages:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.8
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -13984,7 +14427,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       jest-util: 29.7.0
 
   /jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -14015,20 +14458,20 @@ packages:
       jest: ^29.0.0
       typescript: '>=4.4'
     dependencies:
-      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@16.11.7)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
+      '@angular-devkit/build-angular': 16.2.9(@angular/compiler-cli@16.2.11)(@angular/platform-server@16.2.0)(@swc/core@1.3.85)(@types/node@18.7.1)(jest-environment-jsdom@29.4.1)(jest@29.4.1)(stylus@0.59.0)(tailwindcss@3.0.2)(typescript@5.1.3)
       '@angular/compiler-cli': 16.2.11(@angular/compiler@16.2.11)(typescript@5.1.3)
       '@angular/core': 16.2.0(rxjs@7.8.1)(zone.js@0.13.0)
       '@angular/platform-browser-dynamic': 16.2.0(@angular/common@16.2.0)(@angular/compiler@16.2.11)(@angular/core@16.2.0)(@angular/platform-browser@16.2.0)
       bs-logger: 0.2.6
       esbuild-wasm: 0.18.17
-      jest: 29.4.1(@types/node@16.11.7)(ts-node@10.9.1)
+      jest: 29.4.1(@types/node@18.7.1)(ts-node@10.9.1)
       jest-environment-jsdom: 29.4.1
       jest-util: 29.7.0
       pretty-format: 29.7.0
-      ts-jest: 29.1.0(@babel/core@7.23.2)(esbuild@0.18.17)(jest@29.4.1)(typescript@5.1.3)
+      ts-jest: 29.1.0(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.4.1)(typescript@5.1.3)
       typescript: 5.1.3
     optionalDependencies:
-      esbuild: 0.18.17
+      esbuild: 0.19.5
     transitivePeerDependencies:
       - '@babel/core'
       - '@jest/types'
@@ -14087,7 +14530,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -14120,7 +14563,7 @@ packages:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       chalk: 4.1.2
       cjs-module-lexer: 1.2.3
       collect-v8-coverage: 1.0.2
@@ -14176,7 +14619,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -14205,7 +14648,7 @@ packages:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -14219,7 +14662,7 @@ packages:
       }
     engines: { node: '>= 10.13.0' }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -14230,12 +14673,12 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  /jest@29.4.1(@types/node@16.11.7)(ts-node@10.9.1):
+  /jest@29.4.1(@types/node@18.7.1)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==,
@@ -14251,7 +14694,7 @@ packages:
       '@jest/core': 29.7.0(ts-node@10.9.1)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@16.11.7)(ts-node@10.9.1)
+      jest-cli: 29.7.0(@types/node@18.7.1)(ts-node@10.9.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -14640,7 +15083,7 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /less@4.1.3:
@@ -14711,7 +15154,7 @@ packages:
       webpack-sources:
         optional: true
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
       webpack-sources: 3.2.3
     dev: false
 
@@ -14740,6 +15183,43 @@ packages:
         integrity: sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w==,
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+
+  /lint-staged@15.0.2:
+    resolution:
+      {
+        integrity: sha512-vnEy7pFTHyVuDmCAIFKR5QDO8XLVlPFQQyujQ/STOxe40ICWqJ6knS2wSJ/ffX/Lw0rz83luRDh+ET7toN+rOw==,
+      }
+    engines: { node: '>=18.12.0' }
+    hasBin: true
+    dependencies:
+      chalk: 5.3.0
+      commander: 11.1.0
+      debug: 4.3.4
+      execa: 8.0.1
+      lilconfig: 2.1.0
+      listr2: 7.0.2
+      micromatch: 4.0.5
+      pidtree: 0.6.0
+      string-argv: 0.3.2
+      yaml: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /listr2@7.0.2:
+    resolution:
+      {
+        integrity: sha512-rJysbR9GKIalhTbVL2tYbF2hVyDnrf7pFUZBwjPaMIdadYHmeT+EVi/Bu3qd7ETQPahTotg2WRCatXwRBW554g==,
+      }
+    engines: { node: '>=16.0.0' }
+    dependencies:
+      cli-truncate: 3.1.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.1
+      log-update: 5.0.1
+      rfdc: 1.3.0
+      wrap-ansi: 8.1.0
+    dev: false
 
   /loader-runner@4.3.0:
     resolution:
@@ -14865,6 +15345,20 @@ packages:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  /log-update@5.0.1:
+    resolution:
+      {
+        integrity: sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      ansi-escapes: 5.0.0
+      cli-cursor: 4.0.0
+      slice-ansi: 5.0.0
+      strip-ansi: 7.1.0
+      wrap-ansi: 8.1.0
+    dev: false
 
   /loose-envify@1.4.0:
     resolution:
@@ -15189,6 +15683,14 @@ packages:
       }
     engines: { node: '>=6' }
 
+  /mimic-fn@4.0.0:
+    resolution:
+      {
+        integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==,
+      }
+    engines: { node: '>=12' }
+    dev: false
+
   /mini-css-extract-plugin@2.4.7(webpack@5.89.0):
     resolution:
       {
@@ -15199,7 +15701,7 @@ packages:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /mini-css-extract-plugin@2.7.6(webpack@5.88.2):
@@ -15785,6 +16287,16 @@ packages:
     dependencies:
       path-key: 3.1.1
 
+  /npm-run-path@5.1.0:
+    resolution:
+      {
+        integrity: sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      path-key: 4.0.0
+    dev: false
+
   /npmlog@6.0.2:
     resolution:
       {
@@ -15985,6 +16497,16 @@ packages:
     engines: { node: '>=6' }
     dependencies:
       mimic-fn: 2.1.0
+
+  /onetime@6.0.0:
+    resolution:
+      {
+        integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      mimic-fn: 4.0.0
+    dev: false
 
   /open@8.4.2:
     resolution:
@@ -16346,6 +16868,14 @@ packages:
       }
     engines: { node: '>=8' }
 
+  /path-key@4.0.0:
+    resolution:
+      {
+        integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==,
+      }
+    engines: { node: '>=12' }
+    dev: false
+
   /path-parse@1.0.7:
     resolution:
       {
@@ -16413,6 +16943,15 @@ packages:
         integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
       }
     engines: { node: '>=8.6' }
+
+  /pidtree@0.6.0:
+    resolution:
+      {
+        integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==,
+      }
+    engines: { node: '>=0.10' }
+    hasBin: true
+    dev: false
 
   /pify@2.3.0:
     resolution:
@@ -16655,7 +17194,7 @@ packages:
     dependencies:
       lilconfig: 2.1.0
       postcss: 8.4.31
-      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@16.11.7)(typescript@5.1.3)
+      ts-node: 10.9.1(@swc/core@1.3.85)(@types/node@18.7.1)(typescript@5.1.3)
       yaml: 1.10.2
 
   /postcss-loader@6.2.1(postcss@8.4.31)(webpack@5.89.0):
@@ -16672,7 +17211,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.31
       semver: 7.5.4
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /postcss-loader@7.3.3(postcss@8.4.31)(typescript@5.1.3)(webpack@5.88.2):
@@ -17838,6 +18377,17 @@ packages:
       onetime: 5.1.2
       signal-exit: 3.0.7
 
+  /restore-cursor@4.0.0:
+    resolution:
+      {
+        integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==,
+      }
+    engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+    dev: false
+
   /retry@0.12.0:
     resolution:
       {
@@ -17859,6 +18409,13 @@ packages:
         integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==,
       }
     engines: { iojs: '>=1.0.0', node: '>=0.10.0' }
+
+  /rfdc@1.3.0:
+    resolution:
+      {
+        integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==,
+      }
+    dev: false
 
   /rimraf@2.6.3:
     resolution:
@@ -17977,7 +18534,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.69.5
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /sass-loader@13.3.2(sass@1.64.1)(webpack@5.88.2):
@@ -18353,7 +18910,6 @@ packages:
         integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
       }
     engines: { node: '>=14' }
-    dev: true
 
   /sigstore@1.9.0:
     resolution:
@@ -18401,6 +18957,17 @@ packages:
         integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==,
       }
     engines: { node: '>=12' }
+
+  /slice-ansi@5.0.0:
+    resolution:
+      {
+        integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      ansi-styles: 6.2.1
+      is-fullwidth-code-point: 4.0.0
+    dev: false
 
   /smart-buffer@4.2.0:
     resolution:
@@ -18522,7 +19089,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 1.0.2
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /source-map-loader@4.0.1(webpack@5.88.2):
@@ -18749,6 +19316,14 @@ packages:
       commander: 2.20.3
       limiter: 1.1.5
 
+  /string-argv@0.3.2:
+    resolution:
+      {
+        integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==,
+      }
+    engines: { node: '>=0.6.19' }
+    dev: false
+
   /string-length@4.0.2:
     resolution:
       {
@@ -18780,7 +19355,6 @@ packages:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.1.0
-    dev: true
 
   /string_decoder@1.1.1:
     resolution:
@@ -18815,7 +19389,6 @@ packages:
     engines: { node: '>=12' }
     dependencies:
       ansi-regex: 6.0.1
-    dev: true
 
   /strip-bom@3.0.0:
     resolution:
@@ -18837,6 +19410,14 @@ packages:
         integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
       }
     engines: { node: '>=6' }
+
+  /strip-final-newline@3.0.0:
+    resolution:
+      {
+        integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==,
+      }
+    engines: { node: '>=12' }
+    dev: false
 
   /strip-json-comments@3.1.1:
     resolution:
@@ -18866,7 +19447,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
 
   /stylehacks@6.0.0(postcss@8.4.31):
     resolution:
@@ -18895,7 +19476,7 @@ packages:
       fast-glob: 3.3.1
       normalize-path: 3.0.0
       stylus: 0.59.0
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /stylus@0.59.0:
@@ -18973,7 +19554,7 @@ packages:
       webpack: '>=2'
     dependencies:
       '@swc/core': 1.3.85
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: true
 
   /symbol-observable@4.0.0:
@@ -19150,7 +19731,7 @@ packages:
       terser: 5.24.0
       webpack: 5.88.2(@swc/core@1.3.85)(esbuild@0.18.17)
 
-  /terser-webpack-plugin@5.3.9(@swc/core@1.3.85)(esbuild@0.18.17)(webpack@5.89.0):
+  /terser-webpack-plugin@5.3.9(@swc/core@1.3.85)(esbuild@0.19.5)(webpack@5.89.0):
     resolution:
       {
         integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==,
@@ -19171,12 +19752,12 @@ packages:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.20
       '@swc/core': 1.3.85
-      esbuild: 0.18.17
+      esbuild: 0.19.5
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       terser: 5.24.0
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
 
   /terser@5.19.2:
     resolution:
@@ -19365,7 +19946,7 @@ packages:
     engines: { node: '>=6.10' }
     dev: true
 
-  /ts-jest@29.1.0(@babel/core@7.23.2)(esbuild@0.18.17)(jest@29.4.1)(typescript@5.1.3):
+  /ts-jest@29.1.0(@babel/core@7.23.2)(esbuild@0.19.5)(jest@29.4.1)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-ZhNr7Z4PcYa+JjMl62ir+zPiNJfXJN6E8hSLnaUKhOgqcn8vb3e537cpkd0FuAfRK3sR1LSqM1MOhliXNgOFPA==,
@@ -19391,9 +19972,9 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       bs-logger: 0.2.6
-      esbuild: 0.18.17
+      esbuild: 0.19.5
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1(@types/node@16.11.7)(ts-node@10.9.1)
+      jest: 29.4.1(@types/node@18.7.1)(ts-node@10.9.1)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -19419,10 +20000,10 @@ packages:
       semver: 7.5.4
       source-map: 0.7.4
       typescript: 5.1.3
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
-  /ts-node@10.9.1(@swc/core@1.3.85)(@types/node@16.11.7)(typescript@5.1.3):
+  /ts-node@10.9.1(@swc/core@1.3.85)(@types/node@18.7.1)(typescript@5.1.3):
     resolution:
       {
         integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==,
@@ -19445,7 +20026,7 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       acorn: 8.11.2
       acorn-walk: 8.3.0
       arg: 4.1.3
@@ -19589,6 +20170,14 @@ packages:
     engines: { node: '>=8' }
     dev: true
 
+  /type-fest@1.4.0:
+    resolution:
+      {
+        integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==,
+      }
+    engines: { node: '>=10' }
+    dev: false
+
   /type-fest@2.19.0:
     resolution:
       {
@@ -19644,13 +20233,6 @@ packages:
     requiresBuild: true
     dev: true
     optional: true
-
-  /undici-types@5.26.5:
-    resolution:
-      {
-        integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==,
-      }
-    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution:
@@ -20012,7 +20594,7 @@ packages:
       }
     engines: { node: '>= 0.8' }
 
-  /vite@4.4.7(@types/node@16.11.7)(less@4.1.3)(sass@1.64.1)(stylus@0.59.0)(terser@5.19.2):
+  /vite@4.4.7(@types/node@18.7.1)(less@4.1.3)(sass@1.64.1)(stylus@0.59.0)(terser@5.19.2):
     resolution:
       {
         integrity: sha512-6pYf9QJ1mHylfVh39HpuSfMPojPSKVxZvnclX1K1FyZ1PXDOcLBibdq5t1qxJSnL63ca8Wf4zts6mD8u8oc9Fw==,
@@ -20043,7 +20625,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 16.11.7
+      '@types/node': 18.7.1
       esbuild: 0.18.17
       less: 4.1.3
       postcss: 8.4.31
@@ -20157,7 +20739,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
 
   /webpack-dev-middleware@6.1.1(webpack@5.88.2):
     resolution:
@@ -20195,7 +20777,7 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.2.0
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: true
 
   /webpack-dev-server@4.15.1(webpack@5.89.0):
@@ -20242,7 +20824,7 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
       webpack-dev-middleware: 5.3.3(webpack@5.89.0)
       ws: 8.14.2
     transitivePeerDependencies:
@@ -20329,7 +20911,7 @@ packages:
         optional: true
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.18.17)
+      webpack: 5.89.0(@swc/core@1.3.85)(esbuild@0.19.5)
     dev: false
 
   /webpack-virtual-modules@0.5.0:
@@ -20381,7 +20963,7 @@ packages:
       - esbuild
       - uglify-js
 
-  /webpack@5.89.0(@swc/core@1.3.85)(esbuild@0.18.17):
+  /webpack@5.89.0(@swc/core@1.3.85)(esbuild@0.19.5):
     resolution:
       {
         integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==,
@@ -20415,7 +20997,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.18.17)(webpack@5.89.0)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.3.85)(esbuild@0.19.5)(webpack@5.89.0)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -20615,7 +21197,6 @@ packages:
       ansi-styles: 6.2.1
       string-width: 5.1.2
       strip-ansi: 7.1.0
-    dev: true
 
   /wrappy@1.0.2:
     resolution:
@@ -20771,6 +21352,14 @@ packages:
         integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==,
       }
     engines: { node: '>= 6' }
+
+  /yaml@2.3.3:
+    resolution:
+      {
+        integrity: sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==,
+      }
+    engines: { node: '>= 14' }
+    dev: false
 
   /yargs-parser@20.2.9:
     resolution:


### PR DESCRIPTION
Implemented Husky for pre-commit hooks to enhance code quality and consistency. This integration ensures that all committed files pass linting checks and verifies the absence of any inadvertently left 'debugger' statements. Additionally, it automatically formats the staged files for a standardized code presentation.