### PR TITLE
feat(seo): added seo-service

### DIFF
--- a/apps/blog/src/app/app.config.ts
+++ b/apps/blog/src/app/app.config.ts
@@ -18,6 +18,7 @@ import {
 
 import { provideI18n } from '@angular-love/blog/i18n/data-access';
 import { blogShellRoutes } from '@angular-love/blog/shell/feature';
+import { provideSeo } from '@angular-love/seo';
 
 import { environment } from '../environments/environment';
 
@@ -56,6 +57,7 @@ export const appConfig: ApplicationConfig = {
     provideI18n({ routes: blogShellRoutes }),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideClientHydration(),
+    provideSeo(),
     environment.providers,
   ],
 };

--- a/apps/blog/src/index.html
+++ b/apps/blog/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>blog</title>
+    <title>Angular.love</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link type="image/x-icon" rel="icon" href="favicon.ico" />

--- a/libs/blog-bff/articles/api/src/lib/api.ts
+++ b/libs/blog-bff/articles/api/src/lib/api.ts
@@ -48,12 +48,30 @@ app.get('/', wpClientMw, async (c) => {
 app.get('/:slug', wpClientMw, async (c) => {
   const slug = c.req.param('slug');
 
+  const yoast_props = [
+    'title',
+    'description',
+    'robots',
+    'canonical',
+    'og_locale',
+    'og_type',
+    'og_title',
+    'og_description',
+    'og_url',
+    'og_site_name',
+    'article_publisher',
+    'article_modified_time',
+    'og_image',
+    'twitter_card',
+    'twitter_misc',
+  ]
+    .map((p) => `yoast_head_json.${p}`)
+    .join(',');
+
   const result = await c.var.wpClient.get<WPPostDetailsDto[]>('posts', {
     slug: slug,
-    _fields:
-      'id,type,slug,title.rendered,author,content.rendered,date,featured_image_url,author_details,acf',
+    _fields: `id,type,slug,title.rendered,author,content.rendered,date,featured_image_url,author_details,acf,${yoast_props}`,
   });
-
   return c.json(toArticle(result.data[0]));
 });
 

--- a/libs/blog-bff/articles/api/src/lib/dtos.ts
+++ b/libs/blog-bff/articles/api/src/lib/dtos.ts
@@ -19,6 +19,39 @@ export interface WPPostDto {
   };
 }
 
+interface WPPostDetailsDtoYoastData {
+  title: string;
+  description: string;
+  robots: {
+    index: string;
+    follow: string;
+    'max-snippet': string;
+    'max-image-preview': string;
+    'max-video-preview': string;
+  };
+  canonical: string;
+  og_locale: string;
+  og_type: string;
+  og_title: string;
+  og_description: string;
+  og_url: string;
+  og_site_name: string;
+  article_publisher: string;
+  article_published_time: string;
+  article_modified_time: string;
+  og_image: {
+    width: number;
+    height: number;
+    url: string;
+    type: string;
+  }[];
+  twitter_card: string;
+  twitter_misc: {
+    'Napisane przez': string;
+    'Szacowany czas czytania': string;
+  };
+}
+
 export interface WPPostDetailsDto {
   date: string;
   slug: string;
@@ -42,4 +75,5 @@ export interface WPPostDetailsDto {
     reading_time: string | number;
     difficulty: string;
   };
+  yoast_head_json: WPPostDetailsDtoYoastData;
 }

--- a/libs/blog-bff/articles/api/src/lib/mappers.ts
+++ b/libs/blog-bff/articles/api/src/lib/mappers.ts
@@ -31,9 +31,9 @@ export const toArticlePreviewList = (dtos: WPPostDto[]): ArticlePreview[] => {
       readingTime: dto.acf.reading_time.toString() || '5',
       difficulty: dto.acf.difficulty || 'intermediate',
       author: {
-        slug: dto.author_details.slug || '',
-        name: dto.author_details.name || '',
-        avatarUrl: dto.author_details.avatar_url || '',
+        slug: dto.author_details?.slug || '',
+        name: dto.author_details?.name || '',
+        avatarUrl: dto.author_details?.avatar_url || '',
       },
     };
   });
@@ -78,9 +78,9 @@ export const toArticle = (dto?: WPPostDetailsDto): Article => {
     readingTime: dto.acf.reading_time.toString() || '5',
     difficulty: dto.acf.difficulty || 'intermediate',
     author: {
-      slug: dto?.author_details.slug || '',
-      name: dto?.author_details.name || '',
-      description: dto?.author_details.description || '',
+      slug: dto?.author_details?.slug || '',
+      name: dto?.author_details?.name || '',
+      description: dto?.author_details?.description || '',
       avatarUrl: dto?.author_details?.avatar_url || '',
       position: dto?.author_details?.position || '',
       github: dto?.author_details?.github || null,
@@ -89,5 +89,6 @@ export const toArticle = (dto?: WPPostDetailsDto): Article => {
     },
     content: highlightedContent,
     anchors: anchors,
+    seo: dto.yoast_head_json,
   };
 };

--- a/libs/blog-contracts/articles/src/lib/articles.ts
+++ b/libs/blog-contracts/articles/src/lib/articles.ts
@@ -31,6 +31,52 @@ export interface ArticlePreview {
   };
 }
 
+export interface SeoRobotsData {
+  index: string;
+  follow: string;
+  'max-snippet': string;
+  'max-image-preview': string;
+  'max-video-preview': string;
+}
+
+export interface SeoData {
+  title?: string;
+  description?: string;
+  robots?: SeoRobotsData;
+  canonical?: string;
+  og_locale?: string;
+  og_type?: string;
+  og_title?: string;
+  og_description?: string;
+  og_url?: string;
+  og_site_name?: string;
+  article_publisher?: string;
+  article_published_time?: string;
+  article_modified_time?: string;
+  og_image?: {
+    width: number;
+    height: number;
+    url: string;
+    type: string;
+  }[];
+  twitter_card?: string;
+  twitter_misc?: Record<string, string>;
+}
+
+export type SeoMetaData = Pick<
+  SeoData,
+  | 'robots'
+  | 'og_type'
+  | 'canonical'
+  | 'og_url'
+  | 'og_image'
+  | 'article_publisher'
+  | 'article_published_time'
+  | 'article_modified_time'
+  | 'twitter_card'
+  | 'twitter_misc'
+>;
+
 export interface Article {
   title: string;
   slug: string;
@@ -49,4 +95,5 @@ export interface Article {
     linkedin: string | null;
   };
   anchors: Anchor[];
+  seo: SeoData;
 }

--- a/libs/blog/articles/data-access/src/lib/state/article-details.store.ts
+++ b/libs/blog/articles/data-access/src/lib/state/article-details.store.ts
@@ -5,6 +5,7 @@ import { rxMethod } from '@ngrx/signals/rxjs-interop';
 import { pipe, switchMap, tap } from 'rxjs';
 
 import { Article } from '@angular-love/contracts/articles';
+import { withSeo } from '@angular-love/seo';
 import {
   LoadingState,
   withCallState,
@@ -24,6 +25,7 @@ const initialState: ArticleDetailsState = {
 
 export const ArticleDetailsStore = signalStore(
   { providedIn: 'root' },
+  withSeo(),
   withState(initialState),
   withCallState('fetch article details'),
   withMethods(({ ...store }) => {
@@ -46,12 +48,15 @@ export const ArticleDetailsStore = signalStore(
                     slug: slug,
                     fetchArticleDetailsCallState: { error },
                   }),
-                next: (articleDetails) =>
-                  patchState(store, {
+                next: (articleDetails) => {
+                  store.setMeta(articleDetails.seo);
+                  store.setTitle(articleDetails.seo.title);
+                  return patchState(store, {
                     articleDetails,
                     slug: slug,
                     fetchArticleDetailsCallState: LoadingState.LOADED,
-                  }),
+                  });
+                },
               }),
             ),
           ),

--- a/libs/blog/articles/feature-shell/src/lib/routes.ts
+++ b/libs/blog/articles/feature-shell/src/lib/routes.ts
@@ -6,24 +6,36 @@ export const articleRoutes: Routes = [
     loadComponent: async () =>
       (await import('@angular-love/blog/articles/feature/news'))
         .FeatureNewsComponent,
+    data: {
+      seo: { title: 'News' },
+    },
   },
   {
     path: 'guides',
     loadComponent: async () =>
       (await import('@angular-love/blog/articles/feature-guides'))
         .FeatureGuidesComponent,
+    data: {
+      seo: { title: 'Guides' },
+    },
   },
   {
     path: 'latest',
     loadComponent: async () =>
       (await import('@angular-love/feature-latest-articles'))
         .FeatureLatestArticlesPageComponent,
+    data: {
+      seo: { title: 'Latest Articles' },
+    },
   },
   {
     path: 'recommended',
     loadComponent: async () =>
       (await import('@angular-love/recommended-articles'))
         .FeatureRecommendedArticlesPageComponent,
+    data: {
+      seo: { title: 'Recommended Articles' },
+    },
   },
   {
     path: 'article/:articleSlug',

--- a/libs/blog/layouts/ui-layouts/src/lib/header/header.component.html
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/header.component.html
@@ -56,7 +56,11 @@
   class="bg-al-background fixed -top-[100%] left-0 z-50 flex h-full w-full flex-row items-start justify-between p-6 transition-transform duration-300 lg:hidden"
   [ngClass]="{ 'translate-y-[100%]': showNav() }"
 >
-  <al-navigation class="pl-24 pt-24" layout="vertical" />
+  <al-navigation
+    class="pl-24 pt-24"
+    (navigated)="toggleNav()"
+    layout="vertical"
+  />
   <button (click)="toggleNav()">
     <al-icon name="cross" class="h-4 bg-white" />
   </button>

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.html
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.html
@@ -13,6 +13,8 @@
         [attr.aria-Label]="item.ariaLabel"
         [routerLinkActive]="'text-al-pink'"
         [routerLink]="item.link | localize"
+        [ariaLabel]="item.ariaLabel"
+        (click)="navigated.emit()"
       >
         {{ t(item.translationPath) }}
       </a>

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
@@ -1,5 +1,10 @@
 import { NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+} from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslocoDirective } from '@ngneat/transloco';
 import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
@@ -27,6 +32,7 @@ export type NavItem = {
 })
 export class NavigationComponent {
   layout = input<'vertical' | 'horizontal'>('horizontal');
+  navigated = output();
 
   readonly navItems: NavItem[] = [
     {

--- a/libs/blog/search/feature-shell/src/lib/routes.ts
+++ b/libs/blog/search/feature-shell/src/lib/routes.ts
@@ -9,5 +9,8 @@ export const searchRoutes: Route[] = [
       (await import('@angular-love/feature-search-results-page'))
         .SearchResultsPageComponent,
     providers: [provideSearch()],
+    data: {
+      seo: { title: 'Search Results' },
+    },
   },
 ];

--- a/libs/blog/shared/util-seo/.eslintrc.json
+++ b/libs/blog/shared/util-seo/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "al",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "al",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/blog/shared/util-seo/README.md
+++ b/libs/blog/shared/util-seo/README.md
@@ -1,0 +1,7 @@
+# article-seo
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test article-seo` to execute the unit tests.

--- a/libs/blog/shared/util-seo/jest.config.ts
+++ b/libs/blog/shared/util-seo/jest.config.ts
@@ -1,0 +1,22 @@
+/* eslint-disable */
+export default {
+  displayName: 'blog-shared-util-seo',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/blog/shared/util-seo',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/blog/shared/util-seo/project.json
+++ b/libs/blog/shared/util-seo/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "blog-shared-util-seo",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/blog/shared/util-seo/src",
+  "prefix": "al",
+  "projectType": "library",
+  "tags": ["scope:client", "type:util"],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/blog/shared/util-seo/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/blog/shared/util-seo/src/index.ts
+++ b/libs/blog/shared/util-seo/src/index.ts
@@ -1,0 +1,4 @@
+export * from './lib/providers';
+export * from './lib/services';
+export * from './lib/state';
+export * from './lib/tokens';

--- a/libs/blog/shared/util-seo/src/lib/providers/index.ts
+++ b/libs/blog/shared/util-seo/src/lib/providers/index.ts
@@ -1,0 +1,1 @@
+export * from './seo.provider';

--- a/libs/blog/shared/util-seo/src/lib/providers/seo.provider.ts
+++ b/libs/blog/shared/util-seo/src/lib/providers/seo.provider.ts
@@ -1,0 +1,37 @@
+import {
+  APP_INITIALIZER,
+  EnvironmentProviders,
+  inject,
+  makeEnvironmentProviders,
+} from '@angular/core';
+
+import { SeoService } from '../services';
+import { SEO_CONFIG, SeoConfig } from '../tokens';
+
+export const provideSeo = (config?: SeoConfig): EnvironmentProviders => {
+  const defaultConfig: SeoConfig = {
+    locale: 'en_US',
+    description:
+      'Angular.love - ciekawostki oraz rozwiązania dla średnio-zaawansowanych oraz zaawansowanych developerów Angulara.',
+    title: 'Angular.love',
+    siteName: 'Angular.love',
+  };
+
+  return makeEnvironmentProviders([
+    {
+      provide: SEO_CONFIG,
+      useValue: config || defaultConfig,
+    },
+    SeoService,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => {
+        const seoService = inject(SeoService);
+        return () => {
+          seoService.init();
+        };
+      },
+      multi: true,
+    },
+  ]);
+};

--- a/libs/blog/shared/util-seo/src/lib/services/index.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/index.ts
@@ -1,0 +1,3 @@
+export * from './seo-meta-keys';
+export * from './seo-title-keys';
+export * from './seo.service';

--- a/libs/blog/shared/util-seo/src/lib/services/seo-meta-keys.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo-meta-keys.ts
@@ -1,0 +1,25 @@
+export const SEO_META_KEYS = {
+  articleModifiedTime: 'article:modifiedd_time',
+  articlePublishedTime: 'article:published_time',
+  articlePublisher: 'article:publisher',
+  canonical: 'canonical',
+  description: 'description',
+  image: 'image',
+  ogDescription: 'og:description',
+  ogImage: 'og:image',
+  ogImageHeight: 'og:image:height',
+  ogImageWidth: 'og:image:width',
+  ogLocale: 'og:locale',
+  ogSiteName: 'og:site_name',
+  ogType: 'og:type',
+  ogURL: 'og:url',
+  robots: 'robots',
+  twitterCard: 'twitter:card',
+  twitterDescription: 'twitter:description',
+  twitterImage: 'twitter:image',
+  twitterMiscData: 'twitter:data',
+  twitterMiscLabel: 'twitter:label',
+  twitterURL: 'twitter:url',
+} as const;
+
+export type SeoMetaKeys = keyof typeof SEO_META_KEYS;

--- a/libs/blog/shared/util-seo/src/lib/services/seo-title-keys.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo-title-keys.ts
@@ -1,0 +1,7 @@
+export const SEO_TITLE_KEYS = {
+  name: 'name',
+  ogTitle: 'og:title',
+  twitterTitle: 'twitter:title',
+} as const;
+
+export type SeoTitleKeys = keyof typeof SEO_TITLE_KEYS;

--- a/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
@@ -1,0 +1,189 @@
+import { inject, Injectable } from '@angular/core';
+import { Meta, MetaDefinition, Title } from '@angular/platform-browser';
+import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
+import { filter, map, switchMap } from 'rxjs';
+
+import { SeoMetaData } from '@angular-love/contracts/articles';
+
+import { SEO_CONFIG } from '../tokens';
+
+import { SEO_META_KEYS, SeoMetaKeys } from './seo-meta-keys';
+import { SEO_TITLE_KEYS, SeoTitleKeys } from './seo-title-keys';
+
+@Injectable()
+export class SeoService {
+  private readonly _router = inject(Router);
+  private readonly _activatedRoute = inject(ActivatedRoute);
+  private readonly _title = inject(Title);
+  private readonly _meta = inject(Meta);
+  private readonly _seoConfig = inject(SEO_CONFIG);
+
+  init(): void {
+    this._router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        map(() => this._activatedRoute),
+        map((route) => {
+          while (route.firstChild) {
+            route = route.firstChild;
+          }
+          return route;
+        }),
+        switchMap((route) => route?.data),
+      )
+      .subscribe((data) => {
+        this.removeSeo();
+
+        this.updateTag(this._seoConfig.locale, 'ogLocale');
+        this.setMetaDescription(this._seoConfig.description);
+        this.updateTag(this._seoConfig.siteName, 'ogSiteName');
+
+        if (data && data['seo'] && data['seo']['title']) {
+          this.setTitle(`${data['seo']['title']} - ${this._seoConfig.title}`);
+        } else {
+          this.setTitle('');
+        }
+      });
+  }
+
+  setMeta(seoData: SeoMetaData | undefined): void {
+    if (!seoData) {
+      return;
+    }
+
+    if (seoData.robots) {
+      const content = Object.values(seoData.robots).join(', ');
+      this.updateTag(content, 'robots');
+    }
+
+    if (seoData.og_type) {
+      this.updateTag(seoData.og_type, 'ogType');
+    }
+
+    if (seoData.canonical) {
+      this.updateTag(seoData.canonical, 'canonical');
+    }
+
+    if (seoData.og_url) {
+      this.updateTag(seoData.og_url, 'ogURL');
+      this.updateTag(seoData.og_url, 'twitterURL');
+    }
+
+    if (seoData.og_image) {
+      this.setMetaImage(
+        seoData.og_image.map((i) => {
+          return { url: i.url, height: i.height, width: i.width };
+        }),
+      );
+    }
+
+    if (seoData.article_publisher) {
+      this.updateTag(seoData.article_publisher, 'articlePublisher');
+    }
+
+    if (seoData.article_published_time) {
+      this.updateTag(seoData.article_published_time, 'articlePublishedTime');
+    }
+
+    if (seoData.article_modified_time) {
+      this.updateTag(seoData.article_modified_time, 'articleModifiedTime');
+    }
+
+    if (seoData.twitter_card) {
+      this.updateTag(seoData.twitter_card, 'twitterCard');
+    }
+
+    if (seoData.twitter_misc) {
+      this.setMetaTwitterMisc(seoData.twitter_misc);
+    }
+  }
+
+  setTitle(title: string | undefined): void {
+    if (!title) {
+      return;
+    }
+    this._title.setTitle(title);
+    this.updateTag(title, 'ogTitle');
+    this.updateTag(title, 'twitterTitle');
+    this.updateTag(title, 'name');
+  }
+
+  private setMetaTwitterMisc(miscData: object): void {
+    const entries = Object.entries(miscData);
+
+    for (const [index, entry] of entries.entries()) {
+      const label: MetaDefinition = {
+        name: `${SEO_META_KEYS.twitterMiscLabel}${index + 1}`,
+        content: entry[0],
+      };
+
+      const data: MetaDefinition = {
+        name: `${SEO_META_KEYS.twitterMiscData}${index + 1}`,
+        content: entry[1],
+      };
+
+      this._meta.updateTag(label);
+      this._meta.updateTag(data);
+    }
+  }
+
+  private setMetaDescription(metaDescription: string): void {
+    this._meta.removeTag('itemprop="description"'); // Because if we not remove the tag it will not be updated.
+
+    const keys: SeoMetaKeys[] = [
+      'description',
+      'ogDescription',
+      'twitterDescription',
+    ];
+
+    for (const key of keys) {
+      this.updateTag(metaDescription, key);
+    }
+  }
+
+  private setMetaImage(
+    images: {
+      url: string;
+      width: number;
+      height: number;
+    }[],
+  ): void {
+    for (const image of images) {
+      this._meta.removeTag('itemprop="image"'); // Because if we not remove the tag it will not be updated.
+
+      this.updateTag(image.url, 'ogImage');
+      this.updateTag(image.url, 'twitterImage');
+      this.updateTag(image.url, 'image');
+      this.updateTag(`${image.width}`, 'ogImageWidth');
+      this.updateTag(`${image.height}`, 'ogImageHeight');
+    }
+  }
+
+  private updateTag(content: string, name: SeoMetaKeys | SeoTitleKeys): void {
+    const meta: MetaDefinition = {
+      name: name,
+      content: content,
+    };
+
+    this._meta.updateTag(meta);
+  }
+
+  private removeSeo(): void {
+    [...Object.values(SEO_META_KEYS), ...Object.values(SEO_TITLE_KEYS)].forEach(
+      (key) => {
+        if (
+          key === SEO_META_KEYS.twitterMiscData ||
+          key === SEO_META_KEYS.twitterMiscLabel
+        ) {
+          // twitter:data1, twitter:data2, twitter:label1 and twitter:label2 hack
+          this._meta.removeTag(`name="${key}1"`);
+          this._meta.removeTag(`name="${key}2"`);
+        } else {
+          this._meta.removeTag(`name="${key}"`);
+          this._meta.removeTag(`itemprop="${key}"`);
+          this._meta.removeTag(`property="${key}"`);
+        }
+      },
+    );
+  }
+}

--- a/libs/blog/shared/util-seo/src/lib/state/index.ts
+++ b/libs/blog/shared/util-seo/src/lib/state/index.ts
@@ -1,0 +1,1 @@
+export * from './seo.store-feature';

--- a/libs/blog/shared/util-seo/src/lib/state/seo.store-feature.ts
+++ b/libs/blog/shared/util-seo/src/lib/state/seo.store-feature.ts
@@ -1,0 +1,19 @@
+import { inject } from '@angular/core';
+import { signalStoreFeature, withMethods } from '@ngrx/signals';
+
+import { SeoMetaData } from '@angular-love/contracts/articles';
+
+import { SeoService } from '../services';
+
+export function withSeo() {
+  return signalStoreFeature(
+    withMethods((_, seoService = inject(SeoService)) => ({
+      setMeta(meta: SeoMetaData): void {
+        seoService.setMeta(meta);
+      },
+      setTitle(title: string | undefined): void {
+        seoService.setTitle(title);
+      },
+    })),
+  );
+}

--- a/libs/blog/shared/util-seo/src/lib/tokens/index.ts
+++ b/libs/blog/shared/util-seo/src/lib/tokens/index.ts
@@ -1,0 +1,1 @@
+export * from './seo.token';

--- a/libs/blog/shared/util-seo/src/lib/tokens/seo.token.ts
+++ b/libs/blog/shared/util-seo/src/lib/tokens/seo.token.ts
@@ -1,0 +1,10 @@
+import { InjectionToken } from '@angular/core';
+
+export type SeoConfig = {
+  locale: string;
+  description: string;
+  title: string;
+  siteName: string;
+};
+
+export const SEO_CONFIG = new InjectionToken<SeoConfig>('Seo Config');

--- a/libs/blog/shared/util-seo/src/test-setup.ts
+++ b/libs/blog/shared/util-seo/src/test-setup.ts
@@ -1,0 +1,9 @@
+import 'jest-preset-angular/setup-jest';
+
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};

--- a/libs/blog/shared/util-seo/tsconfig.json
+++ b/libs/blog/shared/util-seo/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/blog/shared/util-seo/tsconfig.lib.json
+++ b/libs/blog/shared/util-seo/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/blog/shared/util-seo/tsconfig.spec.json
+++ b/libs/blog/shared/util-seo/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/blog/shell/feature-shell-web/src/lib/blog-shell.routes.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/blog-shell.routes.ts
@@ -15,6 +15,9 @@ export const blogShellRoutes: Route[] = [
         loadComponent: async () =>
           (await import('@angular-love/blog/home/feature-home'))
             .HomePageComponent,
+        data: {
+          seo: { title: 'Home' },
+        },
       },
       ...articleRoutes,
       {
@@ -30,6 +33,9 @@ export const blogShellRoutes: Route[] = [
         loadComponent: async () =>
           (await import('@angular-love/feature-about-us'))
             .FeatureAboutUsComponent,
+        data: {
+          seo: { title: 'About Us' },
+        },
       },
       {
         path: 'author/:authorSlug',
@@ -42,12 +48,18 @@ export const blogShellRoutes: Route[] = [
         loadComponent: async () =>
           (await import('@angular-love/blog/become-author-page-feature'))
             .BecomeAuthorPageFeatureComponent,
+        data: {
+          seo: { title: 'Become an author' },
+        },
       },
       {
         path: 'not-found',
         loadComponent: async () =>
           (await import('@angular-love/blog/shared/ui-not-found'))
             .NotFoundPageComponent,
+        data: {
+          seo: { title: 'Not Found' },
+        },
       },
       {
         path: '**',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -162,6 +162,7 @@
       "@angular-love/search-result-item": [
         "libs/blog/search/ui-search-result/src/index.ts"
       ],
+      "@angular-love/seo": ["libs/blog/shared/util-seo/src/index.ts"],
       "@angular-love/shared/assets": ["libs/shared/assets/src/index.ts"],
       "@angular-love/shared/config": ["libs/shared/config/src/index.ts"],
       "@angular-love/shared/utils-algolia": [


### PR DESCRIPTION
Implements: KAP-9
Fixes: KAP-101

I tried to inlcude all tags from `yoast_head` returned by WP Rest API and from [ngx-seo.service.ts](https://github.com/avivharuzi/ngx-seo/blob/main/packages/ngx-seo/src/lib/ngx-seo.service.ts).

It became pretty big, but there are a lot of tags. 

Currently it is provided and injected in `RootShellComponent`. Let me know if you know a better way to do this. 

Also I fixed mobile navigation (KAP-101)