### PR TITLE
refactor: localized routes

### DIFF
--- a/apps/blog/src/app/app.config.ts
+++ b/apps/blog/src/app/app.config.ts
@@ -33,7 +33,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideRouter(
       blogShellRoutes,
-      withDisabledInitialNavigation(),
+      // withDisabledInitialNavigation(),
       withComponentInputBinding(),
       withViewTransitions({
         onViewTransitionCreated: ({ transition }) => {
@@ -61,7 +61,7 @@ export const appConfig: ApplicationConfig = {
         onSameUrlNavigation: 'reload',
       }),
     ),
-    provideI18n({ routes: blogShellRoutes }),
+    provideI18n(),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideExperimentalZonelessChangeDetection(),
     provideClientHydration(),

--- a/apps/blog/src/app/providers/seo-provider.ts
+++ b/apps/blog/src/app/providers/seo-provider.ts
@@ -3,7 +3,7 @@ import {
   inject,
   makeEnvironmentProviders,
 } from '@angular/core';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 import { map } from 'rxjs';
 
 import { provideSeo } from '@angular-love/seo';

--- a/libs/blog/about-us/feature-about-us/src/lib/feature-about-us/feature-about-us.component.ts
+++ b/libs/blog/about-us/feature-about-us/src/lib/feature-about-us/feature-about-us.component.ts
@@ -5,7 +5,7 @@ import {
   inject,
   OnInit,
 } from '@angular/core';
-import { TranslocoDirective, TranslocoPipe } from '@ngneat/transloco';
+import { TranslocoDirective, TranslocoPipe } from '@jsverse/transloco';
 
 import { AuthorListStore } from '@angular-love/blog/authors/data-access';
 import { AuthorCardComponent } from '@angular-love/blog/authors/ui-author-card';

--- a/libs/blog/ad-banner/ui/src/lib/ad-banner/ad-banner.component.ts
+++ b/libs/blog/ad-banner/ui/src/lib/ad-banner/ad-banner.component.ts
@@ -4,7 +4,7 @@ import {
   input,
   output,
 } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 

--- a/libs/blog/articles/data-access/src/lib/guards/article-exists.guard.ts
+++ b/libs/blog/articles/data-access/src/lib/guards/article-exists.guard.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, isDevMode } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 import { catchError, map, of } from 'rxjs';
 
 import { ArticleDetailsStore } from '../state/article-details.store';

--- a/libs/blog/articles/data-access/src/lib/guards/article-exists.guard.ts
+++ b/libs/blog/articles/data-access/src/lib/guards/article-exists.guard.ts
@@ -4,6 +4,8 @@ import { CanActivateFn, Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
 import { catchError, map, of } from 'rxjs';
 
+import { AlLocalizeService } from '@angular-love/blog/i18n/util';
+
 import { ArticleDetailsStore } from '../state/article-details.store';
 
 export const articleExistsGuard: CanActivateFn = (route) => {
@@ -13,11 +15,17 @@ export const articleExistsGuard: CanActivateFn = (route) => {
   const http = inject(HttpClient);
   const router = inject(Router);
   const transloco = inject(TranslocoService);
+  const localizeService = inject(AlLocalizeService);
+
   const { articleDetails, alternativeLanguageSlug } =
     inject(ArticleDetailsStore);
 
-  const notFoundPageUrlTree = router.createUrlTree(['/', 'not-found']);
-  const homepageUrlTree = router.createUrlTree(['/']);
+  const notFoundPageUrlTree = router.createUrlTree(
+    localizeService.localizePath(['/', 'not-found']),
+  );
+  const homepageUrlTree = router.createUrlTree(
+    localizeService.localizePath(['/']),
+  );
 
   return http
     .get<{
@@ -35,7 +43,10 @@ export const articleExistsGuard: CanActivateFn = (route) => {
         if (articleDetails()?.lang !== transloco.getActiveLang()) {
           // if the article is in the alternative language, redirect to the alternative language page
           if (alternativeLanguageSlug()) {
-            return router.createUrlTree(['/', alternativeLanguageSlug()], {});
+            return router.createUrlTree(
+              localizeService.localizePath(['/', alternativeLanguageSlug()]),
+              {},
+            );
           } else {
             return homepageUrlTree;
           }

--- a/libs/blog/articles/data-access/src/lib/guards/article-exists.guard.ts
+++ b/libs/blog/articles/data-access/src/lib/guards/article-exists.guard.ts
@@ -2,7 +2,6 @@ import { HttpClient } from '@angular/common/http';
 import { inject, isDevMode } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
-import { LocalizeRouterService } from '@penleychan/ngx-transloco-router';
 import { catchError, map, of } from 'rxjs';
 
 import { ArticleDetailsStore } from '../state/article-details.store';
@@ -16,14 +15,9 @@ export const articleExistsGuard: CanActivateFn = (route) => {
   const transloco = inject(TranslocoService);
   const { articleDetails, alternativeLanguageSlug } =
     inject(ArticleDetailsStore);
-  const localizeRouterService = inject(LocalizeRouterService);
 
-  const notFoundPageUrlTree = router.createUrlTree(
-    localizeRouterService.translateRoute(['/', 'not-found']) as string[],
-  );
-  const homepageUrlTree = router.createUrlTree(
-    localizeRouterService.translateRoute(['/']) as string[],
-  );
+  const notFoundPageUrlTree = router.createUrlTree(['/', 'not-found']);
+  const homepageUrlTree = router.createUrlTree(['/']);
 
   return http
     .get<{
@@ -41,11 +35,7 @@ export const articleExistsGuard: CanActivateFn = (route) => {
         if (articleDetails()?.lang !== transloco.getActiveLang()) {
           // if the article is in the alternative language, redirect to the alternative language page
           if (alternativeLanguageSlug()) {
-            const route = localizeRouterService.translateRoute([
-              '/',
-              alternativeLanguageSlug(),
-            ]) as string[];
-            return router.createUrlTree(route, {});
+            return router.createUrlTree(['/', alternativeLanguageSlug()], {});
           } else {
             return homepageUrlTree;
           }

--- a/libs/blog/articles/feature-article/src/lib/article-share-icons/article-share-icons.component.ts
+++ b/libs/blog/articles/feature-article/src/lib/article-share-icons/article-share-icons.component.ts
@@ -1,5 +1,5 @@
 import { Component, computed, input } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { IconComponent, IconType } from '@angular-love/blog/shared/ui-icon';
 import { FastSvgComponent } from "@push-based/ngx-fast-svg";

--- a/libs/blog/articles/feature-comments/src/lib/giscus-comments/giscus-comments.component.ts
+++ b/libs/blog/articles/feature-comments/src/lib/giscus-comments/giscus-comments.component.ts
@@ -8,7 +8,7 @@ import {
 import 'giscus';
 
 import { toSignal } from '@angular/core/rxjs-interop';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 
 import {
   GISCUS_CONFIG,

--- a/libs/blog/articles/feature-latest-articles/src/lib/feature-latest-articles/feature-latest-articles.component.ts
+++ b/libs/blog/articles/feature-latest-articles/src/lib/feature-latest-articles/feature-latest-articles.component.ts
@@ -1,6 +1,6 @@
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ArticleListStore } from '@angular-love/blog/articles/data-access';
 import {

--- a/libs/blog/articles/feature-list/src/lib/category-section-container/category-section-container.component.ts
+++ b/libs/blog/articles/feature-list/src/lib/category-section-container/category-section-container.component.ts
@@ -6,7 +6,7 @@ import {
   input,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ArticleListStore } from '@angular-love/blog/articles/data-access';
 import {

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug]">
+<a [routerLink]="['/', article().slug] | alLocalize">
   <article
     class="h-full rounded-lg bg-cover bg-no-repeat transition-transform hover:scale-105 motion-reduce:transition-none motion-reduce:hover:scale-100"
     [style.background-image]="

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug] | localize">
+<a [routerLink]="['/', article().slug]">
   <article
     class="h-full rounded-lg bg-cover bg-no-repeat transition-transform hover:scale-105 motion-reduce:transition-none motion-reduce:hover:scale-100"
     [style.background-image]="

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.ts
@@ -17,7 +17,6 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
     RouterLink,
     DatePipe,
     UiDifficultyComponent,
-    LocalizeRouterModule,
     FastSvgComponent,
   ],
   templateUrl: './article-compact-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-compact-card/article-compact-card.component.ts
@@ -2,10 +2,10 @@ import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { UiDifficultyComponent } from '@angular-love/blog/shared/ui-difficulty';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 @Component({
@@ -17,6 +17,7 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
     RouterLink,
     DatePipe,
     UiDifficultyComponent,
+    AlLocalizePipe,
     FastSvgComponent,
   ],
   templateUrl: './article-compact-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug]">
+<a [routerLink]="['/', article().slug] | alLocalize">
   <article
     class="hover:shadow-al-primary h-full rounded-lg bg-contain bg-center bg-no-repeat"
     [style.background-image]="

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug] | localize">
+<a [routerLink]="['/', article().slug]">
   <article
     class="hover:shadow-al-primary h-full rounded-lg bg-contain bg-center bg-no-repeat"
     [style.background-image]="

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.ts
@@ -5,7 +5,6 @@ import { RouterLink } from '@angular/router';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { UiDifficultyComponent } from '@angular-love/blog/shared/ui-difficulty';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 export type Layout = 'compact' | 'hero';
@@ -20,7 +19,6 @@ export type Layout = 'compact' | 'hero';
     RouterLink,
     DatePipe,
     UiDifficultyComponent,
-    LocalizeRouterModule,
     FastSvgComponent,
   ],
   templateUrl: './article-hero-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-hero-card/article-hero-card.component.ts
@@ -2,6 +2,7 @@ import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { UiDifficultyComponent } from '@angular-love/blog/shared/ui-difficulty';
@@ -19,6 +20,7 @@ export type Layout = 'compact' | 'hero';
     RouterLink,
     DatePipe,
     UiDifficultyComponent,
+    AlLocalizePipe,
     FastSvgComponent,
   ],
   templateUrl: './article-hero-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug] | localize">
+<a [routerLink]="['/', article().slug]">
   <article
     class="group relative flex h-full w-full flex-row rounded-lg shadow-none"
     [attr.aria-labelledby]="article().slug"

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug]">
+<a [routerLink]="['/', article().slug] | alLocalize">
   <article
     class="group relative flex h-full w-full flex-row rounded-lg shadow-none"
     [attr.aria-labelledby]="article().slug"

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.ts
@@ -13,7 +13,6 @@ import { RouterLink } from '@angular/router';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { UiDifficultyComponent } from '@angular-love/blog/shared/ui-difficulty';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 type SanitizedArticleDataModel = {
@@ -32,7 +31,6 @@ type SanitizedArticleDataModel = {
     RouterLink,
     NgOptimizedImage,
     UiDifficultyComponent,
-    LocalizeRouterModule,
     FastSvgComponent,
   ],
   templateUrl: './article-horizontal-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.ts
@@ -10,6 +10,7 @@ import {
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { UiDifficultyComponent } from '@angular-love/blog/shared/ui-difficulty';
@@ -31,6 +32,7 @@ type SanitizedArticleDataModel = {
     RouterLink,
     NgOptimizedImage,
     UiDifficultyComponent,
+    AlLocalizePipe,
     FastSvgComponent,
   ],
   templateUrl: './article-horizontal-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug] | localize">
+<a [routerLink]="['/', article().slug]">
   <article
     class="hover:shadow-al-primary group relative grid w-full grid-rows-[220px_240px] rounded-lg border border-transparent shadow-none transition-transform hover:scale-105 motion-reduce:transition-none motion-reduce:hover:scale-100"
     [attr.aria-labelledby]="article().slug"

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.html
@@ -1,4 +1,4 @@
-<a [routerLink]="['/', article().slug]">
+<a [routerLink]="['/', article().slug] | alLocalize">
   <article
     class="hover:shadow-al-primary group relative grid w-full grid-rows-[220px_240px] rounded-lg border border-transparent shadow-none transition-transform hover:scale-105 motion-reduce:transition-none motion-reduce:hover:scale-100"
     [attr.aria-labelledby]="article().slug"

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.ts
@@ -9,7 +9,6 @@ import {
 } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
@@ -34,7 +33,6 @@ type SanitizedArticleDataModel = {
     RouterLink,
     NgOptimizedImage,
     UiDifficultyComponent,
-    LocalizeRouterModule,
     FastSvgComponent,
   ],
   templateUrl: './article-regular-card.component.html',

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.ts
@@ -10,6 +10,7 @@ import {
 import { DomSanitizer } from '@angular/platform-browser';
 import { RouterLink } from '@angular/router';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { UiDifficultyComponent } from '@angular-love/blog/shared/ui-difficulty';
@@ -34,6 +35,7 @@ type SanitizedArticleDataModel = {
     NgOptimizedImage,
     UiDifficultyComponent,
     FastSvgComponent,
+    AlLocalizePipe,
   ],
   templateUrl: './article-regular-card.component.html',
 })

--- a/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.html
+++ b/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.html
@@ -7,7 +7,7 @@
   </h2>
   <span class="bg-al-border hidden h-[1px] grow md:block"></span>
   @if (link(); as link) {
-    <a class="text-base underline" [routerLink]="link.href">
+    <a class="text-base underline" [routerLink]="link.href | alLocalize">
       {{ link.displayName }}
     </a>
   }

--- a/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.html
+++ b/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.html
@@ -7,7 +7,7 @@
   </h2>
   <span class="bg-al-border hidden h-[1px] grow md:block"></span>
   @if (link(); as link) {
-    <a class="text-base underline" [routerLink]="link.href | localize">
+    <a class="text-base underline" [routerLink]="link.href">
       {{ link.displayName }}
     </a>
   }

--- a/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.ts
+++ b/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 
 export type ArticleTitleLink = {
   displayName: string;
@@ -12,7 +11,7 @@ export type ArticleTitleLink = {
   standalone: true,
   templateUrl: './ui-article-list-title.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, LocalizeRouterModule],
+  imports: [RouterLink],
 })
 export class UiArticleListTitleComponent {
   title = input.required<string>();

--- a/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.ts
+++ b/libs/blog/articles/ui-article-list-title/src/lib/ui-article-list-title/ui-article-list-title.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
+
 export type ArticleTitleLink = {
   displayName: string;
   href: string;
@@ -11,7 +13,7 @@ export type ArticleTitleLink = {
   standalone: true,
   templateUrl: './ui-article-list-title.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink],
+  imports: [RouterLink, AlLocalizePipe],
 })
 export class UiArticleListTitleComponent {
   title = input.required<string>();

--- a/libs/blog/articles/ui-table-of-contents/src/lib/table-of-contents/table-of-contents.component.ts
+++ b/libs/blog/articles/ui-table-of-contents/src/lib/table-of-contents/table-of-contents.component.ts
@@ -7,7 +7,7 @@ import {
   output,
 } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { Anchor } from '@angular-love/contracts/articles';
 

--- a/libs/blog/authors/feature-author/src/lib/feature-author/feature-author.component.ts
+++ b/libs/blog/authors/feature-author/src/lib/feature-author/feature-author.component.ts
@@ -6,7 +6,7 @@ import {
   input,
   signal,
 } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ArticleListStore } from '@angular-love/blog/articles/data-access';
 import { UiArticleCardComponent } from '@angular-love/blog/articles/ui-article-card';

--- a/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.html
+++ b/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.html
@@ -2,7 +2,7 @@
   <al-author-card-template>
     <ng-container author-info-card>
       @if (linkable()) {
-        <a [routerLink]="['/', 'author', author().slug] | localize">
+        <a [routerLink]="['/', 'author', author().slug]">
           <ng-container *ngTemplateOutlet="avatar" />
         </a>
       } @else {

--- a/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.html
+++ b/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.html
@@ -2,7 +2,7 @@
   <al-author-card-template>
     <ng-container author-info-card>
       @if (linkable()) {
-        <a [routerLink]="['/', 'author', author().slug]">
+        <a [routerLink]="['/', 'author', author().slug] | alLocalize">
           <ng-container *ngTemplateOutlet="avatar" />
         </a>
       } @else {

--- a/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.ts
+++ b/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.ts
@@ -8,6 +8,7 @@ import {
 import { RouterLink } from '@angular/router';
 
 import { UiAuthorCard } from '@angular-love/blog/authors/types';
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
 import { DynamicTextClampComponent } from '@angular-love/blog/shared/ui-dynamic-text-clamp';
 import {
@@ -27,6 +28,7 @@ import { AuthorCardTemplateComponent } from './author-card-template.component';
     RouterLink,
     NgTemplateOutlet,
     SocialMediaIconItemComponent,
+    AlLocalizePipe,
   ],
   templateUrl: './author-card.component.html',
   styleUrl: './author-card.component.scss',

--- a/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.ts
+++ b/libs/blog/authors/ui-author-card/src/lib/author-card/author-card.component.ts
@@ -6,7 +6,6 @@ import {
   input,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 
 import { UiAuthorCard } from '@angular-love/blog/authors/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
@@ -28,7 +27,6 @@ import { AuthorCardTemplateComponent } from './author-card-template.component';
     RouterLink,
     NgTemplateOutlet,
     SocialMediaIconItemComponent,
-    LocalizeRouterModule,
   ],
   templateUrl: './author-card.component.html',
   styleUrl: './author-card.component.scss',

--- a/libs/blog/become-author/feature-become-author-page/src/lib/become-author-page/become-author-page.component.ts
+++ b/libs/blog/become-author/feature-become-author-page/src/lib/become-author-page/become-author-page.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { BreadcrumbComponent } from '@angular-love/blog/shared/ui-breadcrumb';
 import {

--- a/libs/blog/become-author/feature-become-author-page/src/lib/components/become-author-advertisement/become-author-advertisement.component.ts
+++ b/libs/blog/become-author/feature-become-author-page/src/lib/components/become-author-advertisement/become-author-advertisement.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import {
   CardComponent,

--- a/libs/blog/become-author/feature-become-author-page/src/lib/components/become-author-benefits/become-author-benefits.component.ts
+++ b/libs/blog/become-author/feature-become-author-page/src/lib/components/become-author-benefits/become-author-benefits.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { BecomeAuthorListItemComponent } from '../become-author-list-item/become-author-list-item.component';
 

--- a/libs/blog/become-author/feature-become-author-page/src/lib/components/become-author-improvements/become-author-improvements.component.ts
+++ b/libs/blog/become-author/feature-become-author-page/src/lib/components/become-author-improvements/become-author-improvements.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { BecomeAuthorListItemComponent } from '../become-author-list-item/become-author-list-item.component';
 

--- a/libs/blog/home/feature-home/src/lib/home-page/home-page.component.ts
+++ b/libs/blog/home/feature-home/src/lib/home-page/home-page.component.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 
 import { ArticlesListContainerComponent } from '@angular-love/blog/articles/feature-list';
 import { UiArticleCardComponent } from '@angular-love/blog/articles/ui-article-card';

--- a/libs/blog/i18n/data-access/src/index.ts
+++ b/libs/blog/i18n/data-access/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/transloco.loader';
 export * from './lib/providers';
+export * from './lib/resolvers';
 export * from './lib/i18n-headers.interceptor';
 export * from './lib/state/with-lang.state';
 export * from './lib/locale-id.provider';

--- a/libs/blog/i18n/data-access/src/lib/i18n-headers.interceptor.ts
+++ b/libs/blog/i18n/data-access/src/lib/i18n-headers.interceptor.ts
@@ -5,7 +5,7 @@ import {
   HttpRequest,
 } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 import { Observable } from 'rxjs';
 
 @Injectable()

--- a/libs/blog/i18n/data-access/src/lib/locale-id.provider.ts
+++ b/libs/blog/i18n/data-access/src/lib/locale-id.provider.ts
@@ -1,5 +1,5 @@
 import { inject } from '@angular/core';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 
 // Workaround for dynamic locale id
 // Source from open github issue: https://github.com/angular/angular/issues/47637

--- a/libs/blog/i18n/data-access/src/lib/providers.ts
+++ b/libs/blog/i18n/data-access/src/lib/providers.ts
@@ -4,6 +4,8 @@ import localePl from '@angular/common/locales/pl';
 import { isDevMode, LOCALE_ID } from '@angular/core';
 import { provideTransloco } from '@jsverse/transloco';
 
+import { AlLocalizeService } from '@angular-love/blog/i18n/util';
+
 import { I18nHeadersInterceptor } from './i18n-headers.interceptor';
 import { LocaleIdProvider } from './locale-id.provider';
 import { TranslocoHttpLoader } from './transloco.loader';
@@ -28,5 +30,6 @@ export const provideI18n = () => {
       multi: true,
     },
     { provide: LOCALE_ID, useClass: LocaleIdProvider },
+    AlLocalizeService,
   ];
 };

--- a/libs/blog/i18n/data-access/src/lib/providers.ts
+++ b/libs/blog/i18n/data-access/src/lib/providers.ts
@@ -1,14 +1,8 @@
 import { registerLocaleData } from '@angular/common';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import localePl from '@angular/common/locales/pl';
-import { importProvidersFrom, isDevMode, LOCALE_ID } from '@angular/core';
-import { Routes } from '@angular/router';
-import { provideTransloco } from '@ngneat/transloco';
-import {
-  LOCALIZE_ROUTER_CONFIG,
-  localizeRouterConfig,
-  LocalizeRouterModule,
-} from '@penleychan/ngx-transloco-router';
+import { isDevMode, LOCALE_ID } from '@angular/core';
+import { provideTransloco } from '@jsverse/transloco';
 
 import { I18nHeadersInterceptor } from './i18n-headers.interceptor';
 import { LocaleIdProvider } from './locale-id.provider';
@@ -16,9 +10,8 @@ import { TranslocoHttpLoader } from './transloco.loader';
 
 registerLocaleData(localePl);
 
-export const provideI18n = (props: { routes: Routes }) => {
+export const provideI18n = () => {
   return [
-    importProvidersFrom(LocalizeRouterModule.forRoot(props.routes)),
     provideTransloco({
       config: {
         availableLangs: ['pl', 'en'],
@@ -29,17 +22,6 @@ export const provideI18n = (props: { routes: Routes }) => {
       },
       loader: TranslocoHttpLoader,
     }),
-    {
-      provide: LOCALIZE_ROUTER_CONFIG,
-      useValue: localizeRouterConfig({
-        translateRoute: true,
-        initialNavigation: true,
-        alwaysSetPrefix: false,
-        // force fallback language to not be overridden by the browser lang
-        // default: this._cachedLang || browserLang || this.locales[0];
-        defaultLangFunction: () => 'pl',
-      }),
-    },
     {
       provide: HTTP_INTERCEPTORS,
       useClass: I18nHeadersInterceptor,

--- a/libs/blog/i18n/data-access/src/lib/resolvers/active-language.resolver.ts
+++ b/libs/blog/i18n/data-access/src/lib/resolvers/active-language.resolver.ts
@@ -1,0 +1,14 @@
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { TranslocoService } from '@jsverse/transloco';
+
+export const resolveActiveLanguage: (lang: string) => ResolveFn<void> = (
+  lang,
+) => {
+  return () => {
+    const translocoService = inject(TranslocoService);
+    if (translocoService.getActiveLang() !== lang) {
+      translocoService.setActiveLang(lang);
+    }
+  };
+};

--- a/libs/blog/i18n/data-access/src/lib/resolvers/index.ts
+++ b/libs/blog/i18n/data-access/src/lib/resolvers/index.ts
@@ -1,0 +1,1 @@
+export * from './active-language.resolver';

--- a/libs/blog/i18n/data-access/src/lib/state/with-lang.state.ts
+++ b/libs/blog/i18n/data-access/src/lib/state/with-lang.state.ts
@@ -1,6 +1,6 @@
 import { inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 import { signalStoreFeature, withComputed } from '@ngrx/signals';
 
 export const withLangState = () =>

--- a/libs/blog/i18n/data-access/src/lib/transloco.loader.ts
+++ b/libs/blog/i18n/data-access/src/lib/transloco.loader.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { Translation, TranslocoLoader } from '@ngneat/transloco';
+import { Translation, TranslocoLoader } from '@jsverse/transloco';
 
 @Injectable({ providedIn: 'root' })
 export class TranslocoHttpLoader implements TranslocoLoader {

--- a/libs/blog/i18n/util/.eslintrc.json
+++ b/libs/blog/i18n/util/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "al",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "al",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/blog/i18n/util/README.md
+++ b/libs/blog/i18n/util/README.md
@@ -1,0 +1,7 @@
+# blog-i18-util
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test blog-i18-util` to execute the unit tests.

--- a/libs/blog/i18n/util/jest.config.ts
+++ b/libs/blog/i18n/util/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'blog-i18-util',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../../../coverage/libs/blog/i18n/util',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  // https://github.com/jsverse/transloco/issues/714#issuecomment-2028614775
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$|.pnpm|flat/)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/blog/i18n/util/project.json
+++ b/libs/blog/i18n/util/project.json
@@ -1,0 +1,20 @@
+{
+  "name": "blog-i18-util",
+  "$schema": "../../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/blog/i18n/util/src",
+  "prefix": "al",
+  "projectType": "library",
+  "tags": ["scope:client", "type:util"],
+  "targets": {
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "libs/blog/i18n/util/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/libs/blog/i18n/util/src/index.ts
+++ b/libs/blog/i18n/util/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/localize.pipe';
+export * from './lib/localize.service';

--- a/libs/blog/i18n/util/src/lib/localize.pipe.spec.ts
+++ b/libs/blog/i18n/util/src/lib/localize.pipe.spec.ts
@@ -1,0 +1,89 @@
+import { APP_BASE_HREF } from '@angular/common';
+import { ActivatedRoute, RouterLink, UrlTree } from '@angular/router';
+import { TranslocoService } from '@jsverse/transloco';
+import { createPipeFactory, mockProvider } from '@ngneat/spectator/jest';
+
+import { AlLocalizePipe } from './localize.pipe';
+import { AlLocalizeService } from './localize.service';
+
+const baseUrlMock = 'https://test.com';
+
+describe('AlLocalizePipe', () => {
+  const createPipe = createPipeFactory({
+    pipe: AlLocalizePipe,
+    imports: [RouterLink],
+    providers: [
+      AlLocalizeService,
+      mockProvider(ActivatedRoute, {}),
+      {
+        provide: APP_BASE_HREF,
+        useValue: baseUrlMock,
+      },
+    ],
+    template: '<a [routerLink]="value | alLocalize"></a>',
+  });
+
+  const testSetup = (options?: {
+    value?: string | string[] | UrlTree;
+    activeLang?: string;
+    defaultLang?: string;
+  }) => {
+    const spectator = createPipe({
+      providers: [
+        mockProvider(TranslocoService, {
+          getDefaultLang: () => options?.defaultLang ?? 'pl',
+          getActiveLang: () => options?.activeLang ?? 'en',
+        }),
+      ],
+      hostProps: {
+        value: options?.value ?? '/en',
+      },
+    });
+
+    return { spectator };
+  };
+
+  it.each([
+    {
+      options: { value: '/en', activeLang: 'en', defaultLang: 'pl' },
+      result: '/en',
+    },
+    {
+      options: { value: '/', activeLang: 'en', defaultLang: 'pl' },
+      result: '/en',
+    },
+    {
+      options: { value: '/', activeLang: 'pl', defaultLang: 'pl' },
+      result: '/',
+    },
+    {
+      options: { value: '/about-us', activeLang: 'en', defaultLang: 'pl' },
+      result: '/en/about-us',
+    },
+    {
+      options: { value: '/about-us', activeLang: 'pl', defaultLang: 'pl' },
+      result: '/about-us',
+    },
+    {
+      options: {
+        value: ['/', 'nested', 'path'],
+        activeLang: 'pl',
+        defaultLang: 'pl',
+      },
+      result: '/nested/path',
+    },
+    {
+      options: {
+        value: ['/', 'nested', 'path'],
+        activeLang: 'en',
+        defaultLang: 'pl',
+      },
+      result: '/en/nested/path',
+    },
+  ])('translates given path', ({ options, result }) => {
+    const { spectator } = testSetup(options);
+    expect(spectator.element.querySelector('a')?.href).toEqual(
+      `${baseUrlMock}${result}`,
+    );
+  });
+});

--- a/libs/blog/i18n/util/src/lib/localize.pipe.ts
+++ b/libs/blog/i18n/util/src/lib/localize.pipe.ts
@@ -1,0 +1,16 @@
+import { inject, Pipe, type PipeTransform } from '@angular/core';
+import { UrlTree } from '@angular/router';
+
+import { AlLocalizeService } from './localize.service';
+
+@Pipe({
+  name: 'alLocalize',
+  standalone: true,
+})
+export class AlLocalizePipe implements PipeTransform {
+  private readonly _service = inject(AlLocalizeService);
+
+  transform(commandsOrUrlTree: string | UrlTree | any[]): any[] | string {
+    return this._service.localizePath(commandsOrUrlTree);
+  }
+}

--- a/libs/blog/i18n/util/src/lib/localize.service.spec.ts
+++ b/libs/blog/i18n/util/src/lib/localize.service.spec.ts
@@ -1,0 +1,89 @@
+import { TranslocoService } from '@jsverse/transloco';
+import { createServiceFactory, mockProvider } from '@ngneat/spectator/jest';
+
+import { AlLocalizeService } from './localize.service';
+
+describe('AlLocalizeService', () => {
+  const createService = createServiceFactory({
+    service: AlLocalizeService,
+  });
+
+  const testSetup = (options?: {
+    activeLang?: string;
+    defaultLang?: string;
+  }) => {
+    const spectator = createService({
+      providers: [
+        mockProvider(TranslocoService, {
+          getDefaultLang: () => options?.defaultLang ?? 'pl',
+          getActiveLang: () => options?.activeLang ?? 'en',
+        }),
+      ],
+    });
+
+    return { service: spectator.service };
+  };
+
+  describe('localizePath', () => {
+    it.each([
+      {
+        options: { activeLang: 'en', defaultLang: 'pl' },
+        value: '/en',
+        result: '/en',
+      },
+      {
+        options: { activeLang: 'en', defaultLang: 'pl' },
+        value: '/',
+        result: '/en',
+      },
+      {
+        options: { activeLang: 'pl', defaultLang: 'pl' },
+        value: '/',
+        result: '/',
+      },
+      {
+        options: { activeLang: 'en', defaultLang: 'pl' },
+        value: '/about-us',
+        result: '/en/about-us',
+      },
+      {
+        options: { activeLang: 'pl', defaultLang: 'pl' },
+        value: '/about-us',
+        result: '/about-us',
+      },
+      {
+        options: { activeLang: 'en', defaultLang: 'pl' },
+        value: '/nested/path',
+        result: '/en/nested/path',
+      },
+      {
+        options: { activeLang: 'pl', defaultLang: 'pl' },
+        value: '/nested/path',
+        result: '/nested/path',
+      },
+      {
+        options: { activeLang: 'pl', defaultLang: 'pl' },
+        value: ['/', 'path'],
+        result: ['/', 'path'],
+      },
+      {
+        options: { activeLang: 'en', defaultLang: 'pl' },
+        value: ['/', 'path'],
+        result: ['/en', 'path'],
+      },
+      {
+        options: { activeLang: 'pl', defaultLang: 'pl' },
+        value: ['/', 'path', { param: 'test' }],
+        result: ['/', 'path', { param: 'test' }],
+      },
+      {
+        options: { activeLang: 'en', defaultLang: 'pl' },
+        value: ['/', 'path', { param: 'test' }],
+        result: ['/en', 'path', { param: 'test' }],
+      },
+    ])('translates given path', ({ options, value, result }) => {
+      const { service } = testSetup(options);
+      expect(service.localizePath(value)).toEqual(result);
+    });
+  });
+});

--- a/libs/blog/i18n/util/src/lib/localize.service.ts
+++ b/libs/blog/i18n/util/src/lib/localize.service.ts
@@ -1,0 +1,68 @@
+import { inject, Injectable } from '@angular/core';
+import { UrlTree } from '@angular/router';
+import { TranslocoService } from '@jsverse/transloco';
+
+type PathSegment = string | any;
+
+@Injectable()
+export class AlLocalizeService {
+  private readonly _transloco = inject(TranslocoService);
+
+  localizePath(path: any[]): any[];
+  localizePath(path: string | UrlTree): string;
+  localizePath(path: string | UrlTree | any[]): string | any[];
+  localizePath(path: string | UrlTree | any[]): string | any[] {
+    if (typeof path === 'string' || path instanceof UrlTree) {
+      return this.translateStringPath(path.toString());
+    }
+    return this.translateArrayPath(path);
+  }
+
+  localizeExplicitPath(path: string, lang: string): string {
+    return this.addPrefixToUrl(this.cleanupPath(path), lang);
+  }
+
+  private translateStringPath(path: string): string {
+    return path.startsWith('/') ? this.addPrefixToUrl(path) : path;
+  }
+
+  private translateArrayPath(path: PathSegment[]): PathSegment[] {
+    return path.map((segment, index) => {
+      if (typeof segment !== 'string') {
+        return segment;
+      }
+
+      if (index === 0 && segment.startsWith('/')) {
+        return this.addPrefixToUrl(segment);
+      }
+      return segment;
+    });
+  }
+
+  private cleanupPath(path: string): string {
+    let _path = path;
+    const langs = this._transloco.getAvailableLangs() as string[];
+    langs.forEach((lang) => {
+      if (_path.startsWith(`/${lang}`)) {
+        _path = _path.replace(`/${lang}`, '');
+      }
+    });
+    return _path;
+  }
+
+  private addPrefixToUrl(
+    url: string,
+    activeLang = this._transloco.getActiveLang(),
+  ): string {
+    const defaultLang = this._transloco.getDefaultLang();
+
+    if (
+      !url.startsWith(`/${activeLang}/`) &&
+      activeLang !== defaultLang &&
+      url !== `/${activeLang}`
+    ) {
+      return url === '/' ? `/${activeLang}` : `/${activeLang}${url}`;
+    }
+    return url;
+  }
+}

--- a/libs/blog/i18n/util/src/test-setup.ts
+++ b/libs/blog/i18n/util/src/test-setup.ts
@@ -1,0 +1,9 @@
+import 'jest-preset-angular/setup-jest';
+
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};

--- a/libs/blog/i18n/util/tsconfig.json
+++ b/libs/blog/i18n/util/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "useDefineForClassFields": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/blog/i18n/util/tsconfig.lib.json
+++ b/libs/blog/i18n/util/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/libs/blog/i18n/util/tsconfig.spec.json
+++ b/libs/blog/i18n/util/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/blog/layouts/ui-layouts/src/lib/header/header.component.html
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/header.component.html
@@ -5,7 +5,7 @@
     <a
       data-testid="header-home"
       class="flex items-center gap-2"
-      [routerLink]="'/'"
+      [routerLink]="'/' | alLocalize"
     >
       <img
         alt="Angular Love logo"

--- a/libs/blog/layouts/ui-layouts/src/lib/header/header.component.html
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/header.component.html
@@ -5,7 +5,7 @@
     <a
       data-testid="header-home"
       class="flex items-center gap-2"
-      [routerLink]="'/' | localize"
+      [routerLink]="'/'"
     >
       <img
         alt="Angular Love logo"

--- a/libs/blog/layouts/ui-layouts/src/lib/header/header.component.ts
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/header.component.ts
@@ -9,6 +9,7 @@ import {
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslocoDirective } from '@jsverse/transloco';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { NavigationComponent } from '@angular-love/blog/layouts/ui-navigation';
 import { SocialMediaIconsComponent } from '@angular-love/blog/shared/ui-social-media-icons';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
@@ -27,6 +28,7 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
     NavigationComponent,
     NgClass,
     TranslocoDirective,
+    AlLocalizePipe,
     FastSvgComponent,
   ],
 })
@@ -36,8 +38,6 @@ export class HeaderComponent {
   languageChange = output<string>();
 
   showNav = signal<boolean>(false);
-
-  readonly logoSize = '40';
 
   toggleNav(): void {
     this.showNav.set(!this.showNav());

--- a/libs/blog/layouts/ui-layouts/src/lib/header/header.component.ts
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/header.component.ts
@@ -7,7 +7,7 @@ import {
   signal,
 } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { NavigationComponent } from '@angular-love/blog/layouts/ui-navigation';
 import { SocialMediaIconsComponent } from '@angular-love/blog/shared/ui-social-media-icons';

--- a/libs/blog/layouts/ui-layouts/src/lib/header/header.component.ts
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/header.component.ts
@@ -11,7 +11,6 @@ import { TranslocoDirective } from '@ngneat/transloco';
 
 import { NavigationComponent } from '@angular-love/blog/layouts/ui-navigation';
 import { SocialMediaIconsComponent } from '@angular-love/blog/shared/ui-social-media-icons';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 @Component({
@@ -28,7 +27,6 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
     NavigationComponent,
     NgClass,
     TranslocoDirective,
-    LocalizeRouterModule,
     FastSvgComponent,
   ],
 })

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.html
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.html
@@ -23,7 +23,7 @@
             [attr.data-testid]="item.dataTestId"
             class="text-al-foreground p-2 font-medium md:p-6"
             [routerLinkActive]="'text-al-pink'"
-            [routerLink]="item.link | localize"
+            [routerLink]="item.link"
             (click)="navigated.emit()"
           >
             {{ t(item.translationPath) }}

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.html
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.html
@@ -23,7 +23,7 @@
             [attr.data-testid]="item.dataTestId"
             class="text-al-foreground p-2 font-medium md:p-6"
             [routerLinkActive]="'text-al-pink'"
-            [routerLink]="item.link"
+            [routerLink]="item.link | alLocalize"
             (click)="navigated.emit()"
           >
             {{ t(item.translationPath) }}

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
@@ -8,6 +8,8 @@ import {
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslocoDirective } from '@jsverse/transloco';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
+
 export type NavItem = {
   translationPath: string;
   link: string[];
@@ -18,7 +20,13 @@ export type NavItem = {
 @Component({
   selector: 'al-navigation',
   standalone: true,
-  imports: [RouterLink, RouterLinkActive, NgClass, TranslocoDirective],
+  imports: [
+    RouterLink,
+    RouterLinkActive,
+    NgClass,
+    TranslocoDirective,
+    AlLocalizePipe,
+  ],
   templateUrl: './navigation.component.html',
   styleUrl: './navigation.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
@@ -7,7 +7,6 @@ import {
 } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 import { TranslocoDirective } from '@ngneat/transloco';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 
 export type NavItem = {
   translationPath: string;
@@ -19,13 +18,7 @@ export type NavItem = {
 @Component({
   selector: 'al-navigation',
   standalone: true,
-  imports: [
-    RouterLink,
-    RouterLinkActive,
-    NgClass,
-    LocalizeRouterModule,
-    TranslocoDirective,
-  ],
+  imports: [RouterLink, RouterLinkActive, NgClass, TranslocoDirective],
   templateUrl: './navigation.component.html',
   styleUrl: './navigation.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
+++ b/libs/blog/layouts/ui-navigation/src/lib/navigation/navigation.component.ts
@@ -6,7 +6,7 @@ import {
   output,
 } from '@angular/core';
 import { RouterLink, RouterLinkActive } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 export type NavItem = {
   translationPath: string;

--- a/libs/blog/newsletter/feature-newsletter/src/lib/feature-newsletter/newsletter.component.ts
+++ b/libs/blog/newsletter/feature-newsletter/src/lib/feature-newsletter/newsletter.component.ts
@@ -12,15 +12,15 @@ import {
 } from '@angular/forms';
 import { Router } from '@angular/router';
 import { TranslocoDirective } from '@jsverse/transloco';
+import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
+import { AlLocalizeService } from '@angular-love/blog/i18n/util';
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 import {
   CardComponent,
   GradientCardDirective,
 } from '@angular-love/blog/shared/ui-card';
 import { NewsletterStore } from '@angular-love/data-access';
-import { LocalizeRouterService } from '@penleychan/ngx-transloco-router';
-import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 @Component({
   selector: 'al-newsletter',
@@ -52,9 +52,14 @@ export class NewsletterComponent {
 
   private readonly _newsletterStore = inject(NewsletterStore);
   private readonly _router = inject(Router);
+  private readonly _localizeService = inject(AlLocalizeService);
   private readonly _onSuccess = effect(() => {
     if (this.newsletterStoreLoading() !== 'success') return;
-    this._router.navigate(['/newsletter']);
+    this._router.navigate(this._localizeService.localizePath(['/newsletter']), {
+      queryParams: {
+        nm: 'confirmed',
+      },
+    });
   });
 
   protected readonly newsletterStoreLoading = this._newsletterStore.loading;

--- a/libs/blog/newsletter/feature-newsletter/src/lib/feature-newsletter/newsletter.component.ts
+++ b/libs/blog/newsletter/feature-newsletter/src/lib/feature-newsletter/newsletter.component.ts
@@ -52,17 +52,9 @@ export class NewsletterComponent {
 
   private readonly _newsletterStore = inject(NewsletterStore);
   private readonly _router = inject(Router);
-  private readonly _localizeRouter = inject(LocalizeRouterService);
   private readonly _onSuccess = effect(() => {
     if (this.newsletterStoreLoading() !== 'success') return;
-    this._router.navigate(
-      this._localizeRouter.translateRoute(['/newsletter']) as string[],
-      {
-        queryParams: {
-          nm: 'confirmed',
-        },
-      },
-    );
+    this._router.navigate(['/newsletter']);
   });
 
   protected readonly newsletterStoreLoading = this._newsletterStore.loading;

--- a/libs/blog/newsletter/feature-newsletter/src/lib/feature-newsletter/newsletter.component.ts
+++ b/libs/blog/newsletter/feature-newsletter/src/lib/feature-newsletter/newsletter.component.ts
@@ -11,7 +11,7 @@ import {
   Validators,
 } from '@angular/forms';
 import { Router } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 import {

--- a/libs/blog/newsletter/feature-newsletter/src/lib/page/newsletter-page.component.ts
+++ b/libs/blog/newsletter/feature-newsletter/src/lib/page/newsletter-page.component.ts
@@ -12,7 +12,6 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
   standalone: true,
   imports: [
     RouterLink,
-    LocalizeRouterModule,
     ButtonComponent,
     TranslocoDirective,
     A11yModule,
@@ -32,7 +31,7 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
       <p class="my-3">
         {{ t('description') }}
       </p>
-      <a [routerLink]="['/'] | localize">
+      <a [routerLink]="['/']">
         <button al-button type="button" cdkFocusInitial>
           {{ t('button') }}
         </button>

--- a/libs/blog/newsletter/feature-newsletter/src/lib/page/newsletter-page.component.ts
+++ b/libs/blog/newsletter/feature-newsletter/src/lib/page/newsletter-page.component.ts
@@ -1,7 +1,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';

--- a/libs/blog/newsletter/feature-newsletter/src/lib/page/newsletter-page.component.ts
+++ b/libs/blog/newsletter/feature-newsletter/src/lib/page/newsletter-page.component.ts
@@ -3,8 +3,8 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoDirective } from '@jsverse/transloco';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 @Component({
@@ -15,6 +15,7 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
     ButtonComponent,
     TranslocoDirective,
     A11yModule,
+    AlLocalizePipe,
     FastSvgComponent,
   ],
   template: `
@@ -31,7 +32,7 @@ import { FastSvgComponent } from '@push-based/ngx-fast-svg';
       <p class="my-3">
         {{ t('description') }}
       </p>
-      <a [routerLink]="['/']">
+      <a [routerLink]="['/'] | alLocalize">
         <button al-button type="button" cdkFocusInitial>
           {{ t('button') }}
         </button>

--- a/libs/blog/partners/ui-partners/src/lib/partners/partners.component.ts
+++ b/libs/blog/partners/ui-partners/src/lib/partners/partners.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { Partner } from '@angular-love/blog/shared/types';
 

--- a/libs/blog/search/data-access/src/lib/infrastructure/algolia-search.service.ts
+++ b/libs/blog/search/data-access/src/lib/infrastructure/algolia-search.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 
 import { AlgoliaClientService } from '@angular-love/shared/utils-algolia';
 import { convertLangToLocale } from '@angular-love/shared/utils-i18n';

--- a/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.html
+++ b/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.html
@@ -29,7 +29,7 @@
         <p>{{ t('results', { total: searchStore.total() }) }}</p>
         <ul class="max-h-[50vh] overflow-auto">
           @for (item of searchStore.items(); track item.slug) {
-            <a [routerLink]="['/', item.slug]">
+            <a [routerLink]="['/', item.slug] | alLocalize">
               <li
                 class="w-full cursor-pointer justify-between border-b last:border-none"
               >

--- a/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.html
+++ b/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.html
@@ -29,7 +29,7 @@
         <p>{{ t('results', { total: searchStore.total() }) }}</p>
         <ul class="max-h-[50vh] overflow-auto">
           @for (item of searchStore.items(); track item.slug) {
-            <a [routerLink]="['/', item.slug] | localize">
+            <a [routerLink]="['/', item.slug]">
               <li
                 class="w-full cursor-pointer justify-between border-b last:border-none"
               >

--- a/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.ts
+++ b/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.ts
@@ -15,7 +15,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
-import { TranslocoDirective, TranslocoService } from '@ngneat/transloco';
+import { TranslocoDirective, TranslocoService } from '@jsverse/transloco';
 import { debounceTime, filter, startWith, tap } from 'rxjs';
 
 import { AdBannerStore } from '@angular-love/blog/ad-banner/data-access';

--- a/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.ts
+++ b/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.ts
@@ -39,7 +39,6 @@ import { GlobalSearchService } from '../global-search.service';
     ReactiveFormsModule,
     SearchResultItemComponent,
     RouterLink,
-    LocalizeRouterModule,
     TranslocoDirective,
     NgClass,
     FastSvgComponent,
@@ -63,7 +62,6 @@ export class SearchDialogComponent implements OnInit, OnDestroy {
     viewChild.required<ElementRef<HTMLInputElement>>('searchInput');
   private readonly _router = inject(Router);
   private readonly _destroyRef = inject(DestroyRef);
-  private readonly _localizeRouterService = inject(LocalizeRouterService);
 
   @HostListener('click', ['$event.target']) onClick(target: HTMLElement): void {
     if (target.classList.contains('al-overlay')) {
@@ -124,14 +122,11 @@ export class SearchDialogComponent implements OnInit, OnDestroy {
   goToAllResults(): void {
     const totalResults = this.searchStore.total();
     if (totalResults && totalResults > 0) {
-      this._router.navigate(
-        this._localizeRouterService.translateRoute(['search']) as string[],
-        {
-          queryParams: {
-            q: this.searchForm.value,
-          },
+      this._router.navigate(['search'], {
+        queryParams: {
+          q: this.searchForm.value,
         },
-      );
+      });
       this.closeSearch();
     }
   }

--- a/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.ts
+++ b/libs/blog/search/feature-search/src/lib/feature-search/search-dialog/search-dialog.component.ts
@@ -20,14 +20,14 @@ import { debounceTime, filter, startWith, tap } from 'rxjs';
 
 import { AdBannerStore } from '@angular-love/blog/ad-banner/data-access';
 import {
+  AlLocalizePipe,
+  AlLocalizeService,
+} from '@angular-love/blog/i18n/util';
+import {
   GlobalSearchStore,
   provideSearch,
 } from '@angular-love/blog/search/data-access';
 import { SearchResultItemComponent } from '@angular-love/search-result-item';
-import {
-  LocalizeRouterModule,
-  LocalizeRouterService,
-} from '@penleychan/ngx-transloco-router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 import { GlobalSearchService } from '../global-search.service';
@@ -42,6 +42,7 @@ import { GlobalSearchService } from '../global-search.service';
     TranslocoDirective,
     NgClass,
     FastSvgComponent,
+    AlLocalizePipe,
   ],
   templateUrl: './search-dialog.component.html',
   styleUrl: './search-dialog.component.scss',
@@ -62,6 +63,7 @@ export class SearchDialogComponent implements OnInit, OnDestroy {
     viewChild.required<ElementRef<HTMLInputElement>>('searchInput');
   private readonly _router = inject(Router);
   private readonly _destroyRef = inject(DestroyRef);
+  private readonly _localizeService = inject(AlLocalizeService);
 
   @HostListener('click', ['$event.target']) onClick(target: HTMLElement): void {
     if (target.classList.contains('al-overlay')) {
@@ -122,7 +124,7 @@ export class SearchDialogComponent implements OnInit, OnDestroy {
   goToAllResults(): void {
     const totalResults = this.searchStore.total();
     if (totalResults && totalResults > 0) {
-      this._router.navigate(['search'], {
+      this._router.navigate(this._localizeService.localizePath(['search']), {
         queryParams: {
           q: this.searchForm.value,
         },

--- a/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,5 @@
 <div class="mb-10 flex gap-1.5">
-  <a *transloco="let t" class="text-al-muted" [routerLink]="['/'] | localize">
+  <a *transloco="let t" class="text-al-muted" [routerLink]="['/']">
     {{ t('nav.home') }}
   </a>
   <span class="text-al-muted">/</span>

--- a/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.html
+++ b/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.html
@@ -1,5 +1,5 @@
 <div class="mb-10 flex gap-1.5">
-  <a *transloco="let t" class="text-al-muted" [routerLink]="['/']">
+  <a *transloco="let t" class="text-al-muted" [routerLink]="['/'] | alLocalize">
     {{ t('nav.home') }}
   </a>
   <span class="text-al-muted">/</span>

--- a/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 @Component({
   selector: 'al-breadcrumb',

--- a/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.ts
@@ -2,10 +2,12 @@ import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoDirective } from '@jsverse/transloco';
 
+import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
+
 @Component({
   selector: 'al-breadcrumb',
   standalone: true,
-  imports: [TranslocoDirective, RouterLink],
+  imports: [TranslocoDirective, RouterLink, AlLocalizePipe],
   templateUrl: './breadcrumb.component.html',
   styleUrl: './breadcrumb.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.ts
+++ b/libs/blog/shared/ui-breadcrumb/src/lib/breadcrumb/breadcrumb.component.ts
@@ -1,12 +1,11 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { TranslocoDirective } from '@ngneat/transloco';
-import { LocalizeRouterModule } from '@penleychan/ngx-transloco-router';
 
 @Component({
   selector: 'al-breadcrumb',
   standalone: true,
-  imports: [TranslocoDirective, RouterLink, LocalizeRouterModule],
+  imports: [TranslocoDirective, RouterLink],
   templateUrl: './breadcrumb.component.html',
   styleUrl: './breadcrumb.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/libs/blog/shared/ui-difficulty/src/lib/ui-difficulty.component.ts
+++ b/libs/blog/shared/ui-difficulty/src/lib/ui-difficulty.component.ts
@@ -5,7 +5,7 @@ import {
   computed,
   input,
 } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 export type UiDifficulty = 'beginner' | 'intermediate' | 'advanced';
 

--- a/libs/blog/shared/ui-dynamic-text-clamp/src/lib/dynamic-text-clamp/dynamic-text-clamp.component.ts
+++ b/libs/blog/shared/ui-dynamic-text-clamp/src/lib/dynamic-text-clamp/dynamic-text-clamp.component.ts
@@ -5,7 +5,7 @@ import {
   input,
   signal,
 } from '@angular/core';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 

--- a/libs/blog/shared/ui-not-found/src/lib/not-found-page.component.ts
+++ b/libs/blog/shared/ui-not-found/src/lib/not-found-page.component.ts
@@ -1,7 +1,7 @@
 import { NgOptimizedImage } from '@angular/common';
 import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { TranslocoDirective } from '@ngneat/transloco';
+import { TranslocoDirective } from '@jsverse/transloco';
 
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 

--- a/libs/blog/shared/ui-pagination/src/lib/pagination/pagination.component.ts
+++ b/libs/blog/shared/ui-pagination/src/lib/pagination/pagination.component.ts
@@ -6,9 +6,9 @@ import {
   input,
   output,
 } from '@angular/core';
+import { TranslocoDirective } from '@jsverse/transloco';
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroChevronLeft, heroChevronRight } from '@ng-icons/heroicons/outline';
-import { TranslocoDirective } from '@ngneat/transloco';
 
 import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 

--- a/libs/blog/shared/ui-social-media-icons/src/lib/social-media-icons.component.ts
+++ b/libs/blog/shared/ui-social-media-icons/src/lib/social-media-icons.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 
 import {
   SocialMediaIconItemComponent,

--- a/libs/blog/shell/feature-shell-web/src/lib/blog-shell.routes.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/blog-shell.routes.ts
@@ -1,10 +1,26 @@
 import { Route } from '@angular/router';
 
 import { articleRoutes } from '@angular-love/blog/articles/feature/shell';
+import { resolveActiveLanguage } from '@angular-love/blog/i18n/data-access';
 
 import { RootShellComponent } from './root-shell.component';
 
 export const blogShellRoutes: Route[] = [
+  {
+    path: 'en',
+    pathMatch: 'prefix',
+    loadChildren: () => routes,
+    resolve: [resolveActiveLanguage('en')],
+  },
+  {
+    path: '',
+    pathMatch: 'prefix',
+    loadChildren: () => routes,
+    resolve: [resolveActiveLanguage('pl')],
+  },
+];
+
+export const routes: Route[] = [
   {
     path: '',
     component: RootShellComponent,

--- a/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
@@ -2,7 +2,7 @@ import { NgClass, ViewportScroller } from '@angular/common';
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterOutlet } from '@angular/router';
-import { TranslocoService } from '@ngneat/transloco';
+import { TranslocoService } from '@jsverse/transloco';
 import { startWith } from 'rxjs';
 
 import { AdBannerStore } from '@angular-love/blog/ad-banner/data-access';

--- a/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
@@ -3,7 +3,6 @@ import { Component, computed, effect, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterOutlet } from '@angular/router';
 import { TranslocoService } from '@ngneat/transloco';
-import { LocalizeRouterService } from '@penleychan/ngx-transloco-router';
 import { startWith } from 'rxjs';
 
 import { AdBannerStore } from '@angular-love/blog/ad-banner/data-access';
@@ -52,7 +51,6 @@ import { AdBannerComponent } from '@angular-love/blog/shared/ad-banner';
 })
 export class RootShellComponent {
   readonly translocoService = inject(TranslocoService);
-  readonly localizeRouterService = inject(LocalizeRouterService);
 
   protected readonly adBannerStore = inject(AdBannerStore);
 
@@ -76,7 +74,7 @@ export class RootShellComponent {
   );
 
   onLanguageChange(lang: string) {
-    this.localizeRouterService.changeLanguage(lang);
+    // this.localizeRouterService.changeLanguage(lang);
   }
 
   constructor(viewport: ViewportScroller) {

--- a/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
@@ -1,11 +1,12 @@
 import { NgClass, ViewportScroller } from '@angular/common';
 import { Component, computed, effect, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { RouterOutlet } from '@angular/router';
+import { Router, RouterOutlet } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
 import { startWith } from 'rxjs';
 
 import { AdBannerStore } from '@angular-love/blog/ad-banner/data-access';
+import { AlLocalizeService } from '@angular-love/blog/i18n/util';
 import {
   FooterComponent,
   HeaderComponent,
@@ -73,8 +74,13 @@ export class RootShellComponent {
     },
   );
 
+  private readonly _router = inject(Router);
+  private readonly _localizeService = inject(AlLocalizeService);
+
   onLanguageChange(lang: string) {
-    // this.localizeRouterService.changeLanguage(lang);
+    this._router.navigateByUrl(
+      this._localizeService.localizeExplicitPath(this._router.url, lang),
+    );
   }
 
   constructor(viewport: ViewportScroller) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@ngrx/operators": "^17.2.0",
     "@ngrx/signals": "^17.0.1",
     "@nx/angular": "19.1.0",
-    "@penleychan/ngx-transloco-router": "^15.0.1",
     "@push-based/ngx-fast-svg": "^18.0.0",
     "@tailwindcss/container-queries": "^0.1.1",
     "algoliasearch": "^4.23.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@ng-icons/core": "^25.6.0",
     "@ng-icons/heroicons": "^25.6.0",
     "@ng-icons/tabler-icons": "^25.6.0",
-    "@ngneat/transloco": "^6.0.4",
     "@ngrx/operators": "^17.2.0",
     "@ngrx/signals": "^17.0.1",
     "@nx/angular": "19.1.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@angular/platform-server": "18.0.0",
     "@angular/router": "18.0.0",
     "@angular/ssr": "18.0.1",
+    "@jsverse/transloco": "^7.4.2",
     "@ng-icons/bootstrap-icons": "^27.3.1",
     "@ng-icons/core": "^25.6.0",
     "@ng-icons/heroicons": "^25.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ importers:
       '@ng-icons/tabler-icons':
         specifier: ^25.6.0
         version: 25.6.1
-      '@ngneat/transloco':
-        specifier: ^6.0.4
-        version: 6.0.4(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5)
       '@ngrx/operators':
         specifier: ^17.2.0
         version: 17.2.0(rxjs@7.8.1)
@@ -2537,17 +2534,6 @@ packages:
       '@angular/animations': '>= 17.3.0'
       '@angular/common': '>= 17.3.0'
       '@angular/router': '>= 17.3.0'
-
-  '@ngneat/transloco-utils@5.0.0':
-    resolution: {integrity: sha512-e0S+GWyBTmLix9KfYWW/rScYdqQz3z3znNSb+foaA5T3jWs4CPLVo+PV0No7kGjqom8Wy8H3lLvztfhHxYSLyA==}
-    engines: {node: '>=16'}
-    deprecated: 'NOTICE: Transloco has moved to a new scope, this package will no longer receive updates. please use @jsverse/transloco-utils instead.'
-
-  '@ngneat/transloco@6.0.4':
-    resolution: {integrity: sha512-hQSPdmzuxJIu2SBwvoiwjoUjxSnUGFyCOkJnV8IwzzmBSdgQxqMMci5WXg/bQeCYggA+RyXpUjjTudEvkWy5Rw==}
-    deprecated: 'NOTICE: Transloco has moved to a new scope, this package will no longer receive updates. please use @jsverse/transloco instead.'
-    peerDependencies:
-      '@angular/core': '>=16.0.0'
 
   '@ngrx/operators@17.2.0':
     resolution: {integrity: sha512-W7SrGK4VQSJlCtMrkxNChVBDgJGSCdZ4yLBi80xoE9CmhTMMhu9J+8BbDDhZ+PPbTHylKJobkwHq+tJ8mkf4eQ==}
@@ -12340,27 +12326,6 @@ snapshots:
       jquery: 3.6.4
       replace-in-file: 6.2.0
       tslib: 2.6.3
-
-  '@ngneat/transloco-utils@5.0.0(typescript@5.4.5)':
-    dependencies:
-      cosmiconfig: 8.3.6(typescript@5.4.5)
-      tslib: 2.6.3
-    transitivePeerDependencies:
-      - typescript
-
-  '@ngneat/transloco@6.0.4(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5)':
-    dependencies:
-      '@angular/core': 18.0.0(rxjs@7.8.1)(zone.js@0.14.4)
-      '@ngneat/transloco-utils': 5.0.0(typescript@5.4.5)
-      flat: 6.0.1
-      fs-extra: 11.2.0
-      glob: 10.4.1
-      lodash.kebabcase: 4.1.1
-      ora: 5.4.1
-      replace-in-file: 7.2.0
-      tslib: 2.6.3
-    transitivePeerDependencies:
-      - typescript
 
   '@ngrx/operators@17.2.0(rxjs@7.8.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@angular/ssr':
         specifier: 18.0.1
         version: 18.0.1(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))
+      '@jsverse/transloco':
+        specifier: ^7.4.2
+        version: 7.4.2(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5)
       '@ng-icons/bootstrap-icons':
         specifier: ^27.3.1
         version: 27.5.2
@@ -2416,6 +2419,15 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@jsverse/transloco-utils@7.0.1':
+    resolution: {integrity: sha512-Oxs2F5z5UREp2Jgp5KiB8V/VJ6jr1mVIWLJ/UFa3fmIo+4iszHBemgek3QoZaLG7DPUMR2xBWYNzKlGbZCTlMw==}
+    engines: {node: '>=16'}
+
+  '@jsverse/transloco@7.4.2':
+    resolution: {integrity: sha512-PtlaZvriUnvMcpuvAh8H+hAJnxf542NnI/wIYoGTa3x0tgdFHFDtiZZC0Duvr5Dn6rXfV4sMeuSE9IbariMU1w==}
+    peerDependencies:
+      '@angular/core': '>=16.0.0'
 
   '@k11r/nx-cloudflare-wrangler@2.9.1':
     resolution: {integrity: sha512-YUoPCHKd3feJnibw3spbe+tA4XopKEIJNQfxWVH2kvSog4IVawC7EFe0r0Ue/YxCnq/p1k8XqmVAPkD13f4tYw==}
@@ -12214,6 +12226,27 @@ snapshots:
   '@jsonjoy.com/util@1.1.3(tslib@2.6.3)':
     dependencies:
       tslib: 2.6.3
+
+  '@jsverse/transloco-utils@7.0.1(typescript@5.4.5)':
+    dependencies:
+      cosmiconfig: 8.3.6(typescript@5.4.5)
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - typescript
+
+  '@jsverse/transloco@7.4.2(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5)':
+    dependencies:
+      '@angular/core': 18.0.0(rxjs@7.8.1)(zone.js@0.14.4)
+      '@jsverse/transloco-utils': 7.0.1(typescript@5.4.5)
+      flat: 6.0.1
+      fs-extra: 11.2.0
+      glob: 10.4.1
+      lodash.kebabcase: 4.1.1
+      ora: 5.4.1
+      replace-in-file: 7.2.0
+      tslib: 2.6.3
+    transitivePeerDependencies:
+      - typescript
 
   '@k11r/nx-cloudflare-wrangler@2.9.1(@nx/devkit@19.1.0(nx@19.1.0(@swc-node/register@1.8.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.4.5))(@swc/core@1.3.107(@swc/helpers@0.5.11))))(@nx/node@19.1.0(@babel/traverse@7.24.7)(@swc-node/register@1.8.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.4.5))(@swc/core@1.3.107(@swc/helpers@0.5.11))(@types/node@18.19.31)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@19.1.0(@swc-node/register@1.8.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.4.5))(@swc/core@1.3.107(@swc/helpers@0.5.11)))(ts-node@10.9.1(@swc/core@1.3.107(@swc/helpers@0.5.11))(@types/node@18.19.31)(typescript@5.4.5))(typescript@5.4.5))(esbuild@0.19.12)(wrangler@3.62.0(@cloudflare/workers-types@4.20240605.0))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,9 +65,6 @@ importers:
       '@nx/angular':
         specifier: 19.1.0
         version: 19.1.0(@angular-devkit/build-angular@18.0.1(73h66tt5aghstgdq3qg724uk5e))(@angular-devkit/core@18.0.1(chokidar@3.6.0))(@angular-devkit/schematics@18.0.1(chokidar@3.6.0))(@babel/traverse@7.24.7)(@schematics/angular@18.0.1(chokidar@3.6.0))(@swc-node/register@1.8.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.4.5))(@swc/core@1.3.107(@swc/helpers@0.5.11))(@types/node@18.19.31)(@zkochan/js-yaml@0.0.7)(esbuild@0.19.12)(eslint@8.57.0)(html-webpack-plugin@5.6.0(webpack@5.91.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(esbuild@0.19.12)))(nx@19.1.0(@swc-node/register@1.8.0(@swc/core@1.3.107(@swc/helpers@0.5.11))(@swc/types@0.1.7)(typescript@5.4.5))(@swc/core@1.3.107(@swc/helpers@0.5.11)))(rxjs@7.8.1)(typescript@5.4.5)
-      '@penleychan/ngx-transloco-router':
-        specifier: ^15.0.1
-        version: 15.0.1(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(@angular/router@18.0.0(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@18.0.0(@angular/animations@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1))(@ngneat/transloco@6.0.4(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5))
       '@push-based/ngx-fast-svg':
         specifier: ^18.0.0
         version: 18.0.0(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)
@@ -2815,14 +2812,6 @@ packages:
   '@oozcitak/util@8.3.8':
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
-
-  '@penleychan/ngx-transloco-router@15.0.1':
-    resolution: {integrity: sha512-9ipQERd93ab1HPRpMk63gfORoM+JmAbQXiAAhWWLs49C5d+3qjREOD7fplA67/1Yu0YB05H0mQkYGiZrFAfPdQ==}
-    peerDependencies:
-      '@angular/common': '>=15.0.3'
-      '@angular/core': '>=15.0.3'
-      '@angular/router': '>=15.0.3'
-      '@ngneat/transloco': '>=4.0.0'
 
   '@phenomnomnominal/tsquery@5.0.1':
     resolution: {integrity: sha512-3nVv+e2FQwsW8Aw6qTU6f+1rfcJ3hrcnvH/mu9i8YhxO+9sqbOfpL8m6PbET5+xKOlz/VSbp0RoYWYCtIsnmuA==}
@@ -13144,14 +13133,6 @@ snapshots:
       '@oozcitak/util': 8.3.8
 
   '@oozcitak/util@8.3.8': {}
-
-  '@penleychan/ngx-transloco-router@15.0.1(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(@angular/router@18.0.0(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@18.0.0(@angular/animations@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1))(@ngneat/transloco@6.0.4(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5))':
-    dependencies:
-      '@angular/common': 18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1)
-      '@angular/core': 18.0.0(rxjs@7.8.1)(zone.js@0.14.4)
-      '@angular/router': 18.0.0(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(@angular/platform-browser@18.0.0(@angular/animations@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4)))(@angular/common@18.0.0(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(rxjs@7.8.1))(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4)))(rxjs@7.8.1)
-      '@ngneat/transloco': 6.0.4(@angular/core@18.0.0(rxjs@7.8.1)(zone.js@0.14.4))(typescript@5.4.5)
-      tslib: 2.6.3
 
   '@phenomnomnominal/tsquery@5.0.1(typescript@5.4.5)':
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -91,6 +91,7 @@
       "@angular-love/blog/i18n/data-access": [
         "libs/blog/i18n/data-access/src/index.ts"
       ],
+      "@angular-love/blog/i18n/util": ["libs/blog/i18n/util/src/index.ts"],
       "@angular-love/blog/layouts/feature-header": [
         "libs/blog/layouts/feature-header/src/index.ts"
       ],


### PR DESCRIPTION
The main purpose was to remove `ngx-transloco-router` dependency, which is still based on `@ngneat/transloco` that is stopping us from updating to the new `@jsverse/transloco` workspage. 
`@penleychan/ngx-transloco-router` is a fork of `@gilsdav/ngx-translate-router`, which is a fork of `localize-router`. It ends up having a ton of legacy code, making it hard to contribute to keep the library up-to-date. 