### PR TITLE
fix(blog): add missing cdk config

### DIFF
--- a/apps/blog/src/styles.scss
+++ b/apps/blog/src/styles.scss
@@ -1,0 +1,2 @@
+@use '@angular/cdk';
+@include cdk.a11y-visually-hidden();


### PR DESCRIPTION
hide number search result at bottom of page caused by LiveAnnouncer