### PR TITLE
fix(blog): remove white background style for images in article

### DIFF
--- a/libs/blog/articles/ui-article-content/src/lib/article-content/article-content.component.scss
+++ b/libs/blog/articles/ui-article-content/src/lib/article-content/article-content.component.scss
@@ -80,10 +80,6 @@
     @apply list-decimal;
   }
 
-  img {
-    background-color: #ffffff;
-  }
-
   iframe {
     width: 100%;
     min-height: 300px;


### PR DESCRIPTION
Removes the white background from images in the article. See the screenshot below for the visual issue
![image](https://github.com/user-attachments/assets/69a51671-4187-46c9-9fa3-69c446db0adc)
