### PR TITLE
refactor(blog): do not sanitize content in regular cards

### DIFF
--- a/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-horizontal-card/article-horizontal-card.component.html
@@ -5,13 +5,13 @@
   >
     <img
       alt="Post featured image"
-      class="h-auto w-auto rounded-l-lg bg-contain"
+      class="hidden h-auto w-auto rounded-l-lg bg-contain lg:block"
       [ngSrc]="article().featuredImageUrl || 'assets/article-placeholder.webp'"
       [priority]="imagePriority()"
       width="1215"
       height="750"
     />
-    <div class="bg-al-card h-full w-full rounded-r-lg">
+    <div class="bg-al-card h-full w-full rounded-lg lg:rounded-r-lg">
       <div class="flex items-center justify-between px-6 pt-4">
         <div class="flex items-center gap-2">
           <al-avatar
@@ -24,7 +24,7 @@
           </span>
         </div>
         <div class="flex items-center gap-2">
-          <span class="text-sm/[14px]">
+          <span class="hidden text-sm/[14px] lg:block">
             {{ article().publishDate | date: 'dd MMM yyyy' }}
           </span>
           <fast-svg name="clock" size="16" />
@@ -36,14 +36,14 @@
           </time>
         </div>
       </div>
-      <div class="flex flex-col px-6 pt-8">
+      <div class="flex flex-col gap-3 px-6 py-3 lg:gap-6">
         <h3
           class="*:text-al-pink line-clamp-2 text-2xl font-bold *:not-italic"
           [id]="article().slug"
           [innerHTML]="sanitizedArticle().title"
         ></h3>
         <p
-          class="*:text-al-pink line-clamp-3 pt-5 *:font-medium *:not-italic"
+          class="*:text-al-pink line-clamp-3 *:font-medium *:not-italic"
           [innerHTML]="sanitizedArticle().excerpt"
         ></p>
       </div>

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.html
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.html
@@ -34,16 +34,12 @@
         </div>
       </div>
       <div class="flex flex-col gap-3 px-4 pb-4 pt-3">
-        <h3
-          class="*:text-al-pink text-2xl font-bold *:not-italic"
-          [id]="article().slug"
-          [innerHTML]="sanitizedArticle().title"
-          style="word-break: break-word"
-        ></h3>
-        <p
-          class="*:text-al-pink line-clamp-2 *:font-medium *:not-italic"
-          [innerHTML]="sanitizedArticle().excerpt"
-        ></p>
+        <h3 class="text-2xl font-bold" [id]="article().slug">
+          {{ article().title }}
+        </h3>
+        <p class="line-clamp-2">
+          {{ article().excerpt }}
+        </p>
       </div>
     </div>
   </article>

--- a/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.ts
+++ b/libs/blog/articles/ui-article-card/src/lib/components/article-regular-card/article-regular-card.component.ts
@@ -1,24 +1,11 @@
 import { NgOptimizedImage } from '@angular/common';
-import {
-  ChangeDetectionStrategy,
-  Component,
-  computed,
-  inject,
-  input,
-  SecurityContext,
-} from '@angular/core';
-import { DomSanitizer } from '@angular/platform-browser';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
 
 import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
 import { ArticleCard } from '@angular-love/blog/shared/types';
 import { AvatarComponent } from '@angular-love/blog/shared/ui-avatar';
-
-type SanitizedArticleDataModel = {
-  title: string;
-  excerpt: string;
-};
 
 @Component({
   selector: 'al-article-regular-card',
@@ -35,17 +22,4 @@ type SanitizedArticleDataModel = {
 export class ArticleRegularCardComponent {
   readonly article = input.required<ArticleCard>();
   readonly imagePriority = input<number | null>(null);
-
-  sanitizedArticle = computed<SanitizedArticleDataModel>(() => {
-    return {
-      excerpt: this._sanitize(this.article().excerpt),
-      title: this._sanitize(this.article().title),
-    };
-  });
-
-  private readonly _domSanitizer = inject(DomSanitizer);
-
-  private _sanitize(val: string): string {
-    return this._domSanitizer.sanitize(SecurityContext.HTML, val) || '';
-  }
 }

--- a/libs/blog/search/feature-search-results-page/src/lib/search-results-page/search-results-page.component.html
+++ b/libs/blog/search/feature-search-results-page/src/lib/search-results-page/search-results-page.component.html
@@ -1,5 +1,3 @@
-<!--<al-breadcrumb pageName="Search" />-->
-
 <p class="mb-6 mt-8 text-5xl">
   Search:
   <span class="text-al-pink">{{ searchStore.resultQuery() || '-' }}</span>
@@ -8,14 +6,8 @@
 
 <ul class="grid gap-4 md:grid-cols-2 md:gap-6 lg:grid-cols-1 lg:gap-0">
   @for (item of searchStore.items(); track item.slug) {
-    <!-- DESKTOP -->
-    <li class="my-3 hidden h-[220px] lg:block">
+    <li class="my-3">
       <al-article-card [cardType]="'horizontal'" [article]="item" />
-    </li>
-
-    <!-- TABLET AND MOBILE -->
-    <li class="block lg:hidden">
-      <al-article-card [cardType]="'regular'" [article]="item" />
     </li>
   }
 </ul>


### PR DESCRIPTION
Removes extra computation in regular cards. We need that only in horizontal ones. With new UI updates, we can use horizontal cards on both mobile and desktop. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced visual presentation of article cards across devices with improved spacing, borders, and responsive element visibility.
  
- **Refactor**
  - Streamlined content display for article titles and excerpts for clearer readability.
  - Simplified the search results layout for a consistent, device-agnostic appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->