### PR TITLE
fix: remove interaction blocker when modal is hidden by extension

### DIFF
--- a/apps/blog/src/app/providers/tracking/cookie-consent.config.ts
+++ b/apps/blog/src/app/providers/tracking/cookie-consent.config.ts
@@ -27,6 +27,15 @@ export const cookieConsentConfig = {
   cookie: {
     name: 'cc_cookie_al',
   },
+  onModalShow: () => {
+    const ccEl = document.getElementById('cc-main');
+    // Check if the cookie consent dialog has been hidden by injected styles from an external extension (e.g., "I don't care about cookies").
+    // To respect this and avoid issues with the `disablePageInteraction` flag, we manually remove the overlay that blocks page interaction.
+    if (ccEl && window.getComputedStyle(ccEl).display === 'none') {
+      // Reference: https://github.com/orestbida/cookieconsent/blob/e6279509aab5b96be198297b0283b321ad76b0a9/src/utils/constants.js#L8C50-L8C70
+      document.documentElement.classList.remove('disable--interaction');
+    }
+  },
   onConsent: () => {
     window.dataLayer.push({ event: 'consent_update' });
     window.dispatchEvent(new CustomEvent('ptupdate'));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the display behavior of the cookie consent modal to ensure smoother page interactions. If the consent dialog becomes hidden due to external styling effects, full interactivity is automatically restored. Enjoy a more seamless browsing experience with this improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->