### PR TITLE
feat(blog): new invitation link

### DIFF
--- a/libs/blog/writing-rules/feature-writing-rules/src/lib/writing-rules/writing-rules.component.html
+++ b/libs/blog/writing-rules/feature-writing-rules/src/lib/writing-rules/writing-rules.component.html
@@ -9,7 +9,7 @@
     class="lg:pt-15 py-4 md:pb-6"
     [innerHTML]="
       t('writingRules.description2', {
-        link: 'https://discord.gg/jE4uY2nh',
+        link: 'https://discord.com/invite/2K8GMmj5ns',
       })
     "
   ></p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the invitation link in the writing rules section so that users are now directed to the current Discord community invite. This change ensures that the link reflects the latest community channel without altering the overall functionality of the content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->