### PR TITLE
refactor(blog): use h1 as article title

### DIFF
--- a/libs/blog/articles/feature-article/src/lib/article-details/article-details.component.html
+++ b/libs/blog/articles/feature-article/src/lib/article-details/article-details.component.html
@@ -20,9 +20,9 @@
       </div>
     </div>
 
-    <h2 id="article-title" class="flex text-[40px] font-bold">
+    <h1 id="article-title" class="flex text-[40px] font-bold">
       {{ articleDetails().title }}
-    </h2>
+    </h1>
 
     <div class="flex w-full flex-col gap-10 overflow-hidden">
       <al-article-content [content]="articleDetails().content" />

--- a/libs/blog/layouts/ui-layouts/src/lib/header/components/header-logo.component.ts
+++ b/libs/blog/layouts/ui-layouts/src/lib/header/components/header-logo.component.ts
@@ -10,6 +10,7 @@ import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
   template: `
     <a
       data-testid="header-home"
+      aria-label="Home"
       class="flex items-center gap-2"
       [routerLink]="'/' | alLocalize"
     >
@@ -21,7 +22,7 @@ import { AlLocalizePipe } from '@angular-love/blog/i18n/util';
         priority="1"
         ngSrc="assets/angular-love-logo.webp"
       />
-      <h1 class="text-al-primary px-4 text-lg font-bold">angular.love</h1>
+      <div class="text-al-primary px-4 text-lg font-bold">angular.love</div>
     </a>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated article title to use a primary heading for improved structure.
  - Changed header logo text from a heading to a div for semantic consistency.

- **Accessibility**
  - Added an accessible label to the header logo link for better screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->