### PR TITLE
refactor(blog): remove `x-default` hreflang link

### DIFF
--- a/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
@@ -148,15 +148,16 @@ export class SeoService {
       this.appendHreflangLink(entry.locale, fullUrl);
     }
 
-    const defaultEntry =
-      hreflangEntries.find((entry) => entry.locale === 'en') ||
-      hreflangEntries[0];
-    if (defaultEntry) {
-      const defaultUrl = defaultEntry.url.startsWith('http')
-        ? defaultEntry.url
-        : `${this._baseUrl}${defaultEntry.url}`;
-      this.appendHreflangLink('x-default', defaultUrl);
-    }
+    // TODO: validate if x-default impacts SEO
+    // const defaultEntry =
+    //   hreflangEntries.find((entry) => entry.locale === 'en') ||
+    //   hreflangEntries[0];
+    // if (defaultEntry) {
+    //   const defaultUrl = defaultEntry.url.startsWith('http')
+    //     ? defaultEntry.url
+    //     : `${this._baseUrl}${defaultEntry.url}`;
+    //   this.appendHreflangLink('x-default', defaultUrl);
+    // }
   }
 
   clearHreflang(): void {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic addition of the 'x-default' hreflang link for now.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->