### PR TITLE
feat: remove newsletter subscribe on newsletter sub

### DIFF
--- a/libs/blog-bff/newsletter/src/lib/newsletter-client.ts
+++ b/libs/blog-bff/newsletter/src/lib/newsletter-client.ts
@@ -6,17 +6,6 @@ export class NewsletterClient {
     private _apiKey: string,
   ) {}
 
-  getTemplate(templateId: number): Promise<Template> {
-    return this.request<Template>(`smtp/templates/${templateId}`);
-  }
-
-  sendEmail(dto: SendEmailDto): Promise<void> {
-    return this.request<void>(`smtp/email`, {
-      method: 'POST',
-      body: dto,
-    });
-  }
-
   createContact(contact: NewContactDto): Promise<void> {
     return this.request(`contacts`, {
       method: 'POST',


### PR DESCRIPTION
Moving mail sending to automation on brevo that runs when added to a list 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Changes
  - Newsletter subscriptions no longer trigger a welcome email; new subscribers will not receive an immediate welcome message.
  - Subscribing now only adds or updates your contact in the appropriate newsletter list.

- Deprecations
  - Functionality related to fetching email templates and sending emails via the newsletter client has been removed, aligning the subscription flow to contact management only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->