### PR TITLE
Feat/carousel

### DIFF
--- a/apps/blog-analog/src/app/i18n/assets/en.json
+++ b/apps/blog-analog/src/app/i18n/assets/en.json
@@ -312,5 +312,10 @@
       "section1": "We’ll transfer your article to the CMS and schedule its publication.",
       "section2": "We’ll also promote it on social media to maximize its reach."
     }
+  },
+  "relatedArticles": {
+    "title": "Related Articles",
+    "previousSlide": "Previous slide",
+    "nextSlide": "Next slide"
   }
 }

--- a/apps/blog-analog/src/app/i18n/assets/pl.json
+++ b/apps/blog-analog/src/app/i18n/assets/pl.json
@@ -315,5 +315,10 @@
       "section1": "Teraz my zajmiemy się przeniesieniem twojego artykułu do CMS’a i zaplanujemy jego opublikowanie",
       "section2": "Zajmiemy się również jego promowaniem w mediach społecznościowych, aby jak najwięcej osób mogło skorzystać z wiedzy, którą w nim zawarłeś!"
     }
+  },
+  "relatedArticles": {
+    "title": "Powiązane artykuły",
+    "previousSlide": "Poprzedni slajd",
+    "nextSlide": "Następny slajd"
   }
 }

--- a/apps/blog-analog/src/styles.scss
+++ b/apps/blog-analog/src/styles.scss
@@ -3,7 +3,8 @@
 @use 'vanilla-cookieconsent/dist/cookieconsent.css';
 @use '@shared-styles/cookies-consent.scss';
 @use '@angular/cdk';
+@use 'ngx-owl-carousel-o/lib/styles/scss/owl.carousel';
+@use 'ngx-owl-carousel-o/lib/styles/scss/owl.theme.default' as owl-theme;
 @include cdk.a11y-visually-hidden();
 
 @import '@angular/cdk/overlay-prebuilt.css';
-

--- a/apps/blog-analog/vite.config.ts
+++ b/apps/blog-analog/vite.config.ts
@@ -66,5 +66,13 @@ export default defineConfig(({ mode }) => {
       include: ['**/*.spec.ts'],
       reporters: ['default'],
     },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          // quiet ngx-owl-carousel-o warnings
+          quietDeps: true,
+        },
+      },
+    },
   };
 });

--- a/apps/blog/src/assets/i18n/en.json
+++ b/apps/blog/src/assets/i18n/en.json
@@ -314,5 +314,10 @@
       "section1": "We’ll transfer your article to the CMS and schedule its publication.",
       "section2": "We’ll also promote it on social media to maximize its reach."
     }
+  },
+  "relatedArticles": {
+    "title": "Related Articles",
+    "previousSlide": "Previous slide",
+    "nextSlide": "Next slide"
   }
 }

--- a/apps/blog/src/assets/i18n/pl.json
+++ b/apps/blog/src/assets/i18n/pl.json
@@ -317,5 +317,10 @@
       "section1": "Teraz my zajmiemy się przeniesieniem twojego artykułu do CMS’a i zaplanujemy jego opublikowanie",
       "section2": "Zajmiemy się również jego promowaniem w mediach społecznościowych, aby jak najwięcej osób mogło skorzystać z wiedzy, którą w nim zawarłeś!"
     }
+  },
+  "relatedArticles": {
+    "title": "Powiązane artykuły",
+    "previousSlide": "Poprzedni slajd",
+    "nextSlide": "Następny slajd"
   }
 }

--- a/apps/blog/src/styles.scss
+++ b/apps/blog/src/styles.scss
@@ -2,3 +2,5 @@
 @include cdk.a11y-visually-hidden();
 
 @import '@angular/cdk/overlay-prebuilt.css';
+@import 'ngx-owl-carousel-o/lib/styles/scss/owl.carousel';
+@import 'ngx-owl-carousel-o/lib/styles/scss/owl.theme.default';

--- a/apps/blog/src/styles.scss
+++ b/apps/blog/src/styles.scss
@@ -1,6 +1,7 @@
 @use '@angular/cdk';
+@use 'ngx-owl-carousel-o/lib/styles/scss/owl.carousel';
+@use 'ngx-owl-carousel-o/lib/styles/scss/owl.theme.default' as owl-theme;
+
 @include cdk.a11y-visually-hidden();
 
 @import '@angular/cdk/overlay-prebuilt.css';
-@import 'ngx-owl-carousel-o/lib/styles/scss/owl.carousel';
-@import 'ngx-owl-carousel-o/lib/styles/scss/owl.theme.default';

--- a/libs/blog/articles/data-access/src/lib/infrastructure/articles.service.ts
+++ b/libs/blog/articles/data-access/src/lib/infrastructure/articles.service.ts
@@ -36,9 +36,17 @@ export class ArticlesService {
     );
   }
 
-  getRelatedArticles(id: number): Observable<ArrayResponse<ArticlePreview>> {
+  getRelatedArticles(
+    id: number,
+    query?: {
+      limit?: number;
+    },
+  ): Observable<ArrayResponse<ArticlePreview>> {
     return this._http.get<ArrayResponse<ArticlePreview>>(
       `${this._apiBaseUrl}/articles/${id}/related`,
+      {
+        params: query || {},
+      },
     );
   }
 }

--- a/libs/blog/articles/data-access/src/lib/state/related-article.store.ts
+++ b/libs/blog/articles/data-access/src/lib/state/related-article.store.ts
@@ -38,7 +38,7 @@ export const RelatedArticleListStore = signalStore(
             }),
           ),
           concatMap((articleId) =>
-            articlesService.getRelatedArticles(articleId).pipe(
+            articlesService.getRelatedArticles(articleId, { limit: 4 }).pipe(
               tap({
                 next: ({ data }) => {
                   patchState(store, {

--- a/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
+++ b/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
@@ -5,6 +5,7 @@ import {
   input,
   OnInit,
 } from '@angular/core';
+import { CarouselModule, OwlOptions } from 'ngx-owl-carousel-o';
 
 import { RelatedArticleListStore } from '@angular-love/blog/articles/data-access';
 import { UiArticleCardComponent } from '@angular-love/blog/articles/ui-article-card';
@@ -14,19 +15,44 @@ import { UiArticleCardComponent } from '@angular-love/blog/articles/ui-article-c
   template: `
     @if (store.isFetchRelatedArticleListLoaded()) {
       <strong class="text-3xl">Related Articles</strong>
-      <div class="mt-4 grid grid-cols-1 gap-6 p-2 md:grid-cols-2">
+      <owl-carousel-o [options]="customOptions">
         @for (article of store.relatedArticles(); track $index) {
-          <al-article-card [article]="article" cardType="compact" />
+          <ng-template carouselSlide>
+            <al-article-card [article]="article" cardType="compact" />
+          </ng-template>
+          <ng-template carouselSlide>
+            <al-article-card [article]="article" cardType="compact" />
+          </ng-template>
         }
-      </div>
+      </owl-carousel-o>
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [RelatedArticleListStore],
-  imports: [UiArticleCardComponent],
+  imports: [UiArticleCardComponent, CarouselModule],
 })
 export class RelatedArticlesComponent implements OnInit {
   readonly id = input.required<number>();
+  customOptions: OwlOptions = {
+    loop: true,
+    mouseDrag: false,
+    touchDrag: true,
+    pullDrag: false,
+    dots: true,
+    margin: 24, // Add spacing between items
+    navSpeed: 700,
+    navText: ['', ''],
+    responsive: {
+      // Keep in mind these breakpoints refer to container width, not the viewport width
+      0: {
+        items: 1,
+      },
+      640: {
+        items: 2,
+      },
+    },
+    nav: true,
+  };
 
   readonly store = inject(RelatedArticleListStore);
 

--- a/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
+++ b/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
@@ -68,7 +68,7 @@ import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 })
 export class RelatedArticlesComponent implements OnInit {
   readonly id = input.required<number>();
-  customOptions: OwlOptions = {
+  readonly customOptions: OwlOptions = {
     loop: true,
     mouseDrag: false,
     touchDrag: true,

--- a/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
+++ b/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
@@ -5,31 +5,66 @@ import {
   input,
   OnInit,
 } from '@angular/core';
+import { TranslocoDirective } from '@jsverse/transloco';
 import { CarouselModule, OwlOptions } from 'ngx-owl-carousel-o';
 
 import { RelatedArticleListStore } from '@angular-love/blog/articles/data-access';
 import { UiArticleCardComponent } from '@angular-love/blog/articles/ui-article-card';
+import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
 
 @Component({
   selector: 'al-related-articles',
   template: `
     @if (store.isFetchRelatedArticleListLoaded()) {
-      <strong class="text-3xl">Related Articles</strong>
-      <owl-carousel-o [options]="customOptions">
-        @for (article of store.relatedArticles(); track $index) {
-          <ng-template carouselSlide>
-            <al-article-card [article]="article" cardType="compact" />
-          </ng-template>
-          <ng-template carouselSlide>
-            <al-article-card [article]="article" cardType="compact" />
-          </ng-template>
-        }
-      </owl-carousel-o>
+      <ng-container *transloco="let t; read: 'relatedArticles'">
+        <h2 class="mb-4 text-3xl font-bold">{{ t('title') }}</h2>
+        <div class="relative lg:px-14">
+          <owl-carousel-o #carousel role="list" [options]="customOptions">
+            @for (article of store.relatedArticles(); track $index) {
+              <ng-template carouselSlide>
+                <!-- Prevents focus rings from being cut off -->
+                <li class="list-none py-1">
+                  <al-article-card [article]="article" cardType="compact" />
+                </li>
+              </ng-template>
+            }
+          </owl-carousel-o>
+          <div
+            class="absolute left-0 top-1/2 hidden w-full -translate-y-1/2 justify-between lg:flex"
+          >
+            <button
+              al-button
+              type="button"
+              class="bg-al-pink text-white"
+              [attr.aria-label]="t('previousSlide')"
+              (click)="carousel.prev()"
+              size="small"
+            >
+              <span class="text-2xl">‹</span>
+            </button>
+            <button
+              al-button
+              type="button"
+              class="bg-al-pink text-white"
+              [attr.aria-label]="t('nextSlide')"
+              (click)="carousel.next()"
+              size="small"
+            >
+              <span class="text-2xl">›</span>
+            </button>
+          </div>
+        </div>
+      </ng-container>
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [RelatedArticleListStore],
-  imports: [UiArticleCardComponent, CarouselModule],
+  imports: [
+    UiArticleCardComponent,
+    CarouselModule,
+    ButtonComponent,
+    TranslocoDirective,
+  ],
 })
 export class RelatedArticlesComponent implements OnInit {
   readonly id = input.required<number>();
@@ -37,9 +72,9 @@ export class RelatedArticlesComponent implements OnInit {
     loop: true,
     mouseDrag: false,
     touchDrag: true,
-    pullDrag: false,
+    pullDrag: true,
     dots: true,
-    margin: 24, // Add spacing between items
+    margin: 24,
     navSpeed: 700,
     navText: ['', ''],
     responsive: {
@@ -47,11 +82,10 @@ export class RelatedArticlesComponent implements OnInit {
       0: {
         items: 1,
       },
-      640: {
+      540: {
         items: 2,
       },
     },
-    nav: true,
   };
 
   readonly store = inject(RelatedArticleListStore);

--- a/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
+++ b/libs/blog/articles/feature-related-articles/src/lib/related-articles.component.ts
@@ -18,7 +18,7 @@ import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
     @if (store.isFetchRelatedArticleListLoaded()) {
       <ng-container *transloco="let t; read: 'relatedArticles'">
         <h2 class="mb-4 text-3xl font-bold">{{ t('title') }}</h2>
-        <div class="relative lg:px-14">
+        <div class="relative lg:px-12">
           <owl-carousel-o #carousel role="list" [options]="customOptions">
             @for (article of store.relatedArticles(); track $index) {
               <ng-template carouselSlide>
@@ -30,7 +30,7 @@ import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
             }
           </owl-carousel-o>
           <div
-            class="absolute left-0 top-1/2 hidden w-full -translate-y-1/2 justify-between lg:flex"
+            class="absolute top-1/2 left-0 hidden w-full -translate-y-1/2 justify-between lg:flex"
           >
             <button
               al-button
@@ -74,7 +74,8 @@ export class RelatedArticlesComponent implements OnInit {
     touchDrag: true,
     pullDrag: true,
     dots: true,
-    margin: 24,
+    margin: 12,
+    stagePadding: 8,
     navSpeed: 700,
     navText: ['', ''],
     responsive: {

--- a/libs/blog/shared/ui-avatar/src/lib/avatar.component.html
+++ b/libs/blog/shared/ui-avatar/src/lib/avatar.component.html
@@ -1,5 +1,7 @@
 <div
   class="flex items-center justify-center overflow-hidden rounded-full border border-white bg-gray-200"
+  [style.width.px]="size()"
+  [style.height.px]="size()"
 >
   @if (imageSrc()) {
     <img

--- a/libs/blog/shared/ui-avatar/src/lib/avatar.component.ts
+++ b/libs/blog/shared/ui-avatar/src/lib/avatar.component.ts
@@ -9,9 +9,6 @@ type AvatarSize = '32' | '96';
   styleUrls: ['./avatar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgOptimizedImage],
-  host: {
-    class: 'block',
-  },
 })
 export class AvatarComponent {
   readonly imageSrc = input.required<string>();

--- a/libs/blog/shared/ui-avatar/src/lib/avatar.component.ts
+++ b/libs/blog/shared/ui-avatar/src/lib/avatar.component.ts
@@ -9,6 +9,9 @@ type AvatarSize = '32' | '96';
   styleUrls: ['./avatar.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgOptimizedImage],
+  host: {
+    class: 'block',
+  },
 })
 export class AvatarComponent {
   readonly imageSrc = input.required<string>();

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "marked-highlight": "^2.2.1",
     "marked-mangle": "^1.1.10",
     "mermaid": "^10.2.4",
+    "ngx-owl-carousel-o": "^21.0.3",
     "ngx-skeleton-loader": "^8.1.0",
     "panzoom": "^9.4.3",
     "prettier-plugin-organize-attributes": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "marked-highlight": "^2.2.1",
     "marked-mangle": "^1.1.10",
     "mermaid": "^10.2.4",
-    "ngx-owl-carousel-o": "^21.0.3",
+    "ngx-owl-carousel-o": "^20.1.1",
     "ngx-skeleton-loader": "^8.1.0",
     "panzoom": "^9.4.3",
     "prettier-plugin-organize-attributes": "^1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       mermaid:
         specifier: ^10.2.4
         version: 10.9.5
+      ngx-owl-carousel-o:
+        specifier: ^21.0.3
+        version: 21.0.3(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2)
       ngx-skeleton-loader:
         specifier: ^8.1.0
         version: 8.1.0(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))
@@ -10384,6 +10387,13 @@ packages:
 
   ngraph.events@1.2.2:
     resolution: {integrity: sha512-JsUbEOzANskax+WSYiAPETemLWYXmixuPAlmZmhIbIj6FH/WDgEGCGnRwUQBK0GjOnVm8Ui+e5IJ+5VZ4e32eQ==}
+
+  ngx-owl-carousel-o@21.0.3:
+    resolution: {integrity: sha512-3Er0VtaLgzb8yWvPDQhwqvGiKBFJbn3tqXHrmnRANUrB8GtyVcr29tE3XPowQyvNM1bQIn3CT+Km8h4LzJtDZg==}
+    peerDependencies:
+      '@angular/common': ' ^21.0.0-rc.0 || ^21.0.0'
+      '@angular/core': ^21.0.0-rc.0 || ^21.0.0
+      rxjs: ^6.0.1 || ^7.0.0
 
   ngx-skeleton-loader@8.1.0:
     resolution: {integrity: sha512-Ap/QSjadv/Kl0Vj7BiIWLG0JZZlo0eCJhdIVJ3Ryz7R0c4BR2Eq3O01du3ftf0SDbwt5vt7342NyqhLNrQ08RA==}
@@ -25386,6 +25396,13 @@ snapshots:
       tailwindcss: 4.2.1
 
   ngraph.events@1.2.2: {}
+
+  ngx-owl-carousel-o@21.0.3(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2):
+    dependencies:
+      '@angular/common': 20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2)
+      '@angular/core': 20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4)
+      rxjs: 7.8.2
+      tslib: 2.8.1
 
   ngx-skeleton-loader@8.1.0(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: ^10.2.4
         version: 10.9.5
       ngx-owl-carousel-o:
-        specifier: ^21.0.3
-        version: 21.0.3(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2)
+        specifier: ^20.1.1
+        version: 20.1.1(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2)
       ngx-skeleton-loader:
         specifier: ^8.1.0
         version: 8.1.0(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))
@@ -10388,11 +10388,11 @@ packages:
   ngraph.events@1.2.2:
     resolution: {integrity: sha512-JsUbEOzANskax+WSYiAPETemLWYXmixuPAlmZmhIbIj6FH/WDgEGCGnRwUQBK0GjOnVm8Ui+e5IJ+5VZ4e32eQ==}
 
-  ngx-owl-carousel-o@21.0.3:
-    resolution: {integrity: sha512-3Er0VtaLgzb8yWvPDQhwqvGiKBFJbn3tqXHrmnRANUrB8GtyVcr29tE3XPowQyvNM1bQIn3CT+Km8h4LzJtDZg==}
+  ngx-owl-carousel-o@20.1.1:
+    resolution: {integrity: sha512-jyV3LYgeTPVQK+aZpPX8HgsflVfeNQUHLA/CPBc66UwYGRoVJMEwz/KnGRxgb2euxv2AFUmJ4THo7zS5UClQ6Q==}
     peerDependencies:
-      '@angular/common': ' ^21.0.0-rc.0 || ^21.0.0'
-      '@angular/core': ^21.0.0-rc.0 || ^21.0.0
+      '@angular/common': ' ^20.0.0-rc.0 || ^20.0.0'
+      '@angular/core': ^20.0.0-rc.0 || ^20.0.0
       rxjs: ^6.0.1 || ^7.0.0
 
   ngx-skeleton-loader@8.1.0:
@@ -25397,7 +25397,7 @@ snapshots:
 
   ngraph.events@1.2.2: {}
 
-  ngx-owl-carousel-o@21.0.3(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2):
+  ngx-owl-carousel-o@20.1.1(@angular/common@20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2))(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2):
     dependencies:
       '@angular/common': 20.3.10(@angular/core@20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4))(rxjs@7.8.2)
       '@angular/core': 20.3.10(@angular/compiler@20.3.10)(rxjs@7.8.2)(zone.js@0.14.4)


### PR DESCRIPTION
Adds a POC for a related articles wrapper. Currently, it renders 2 elements for each related article returned by the backend for presentation purposes. According to my findings, we need to update the YARPP plugin configuration to change the number of returned related articles from 2 to 4.

I've utilized the [ngx-owl-carousel-o](https://github.com/vitalii-andriiovskyi/ngx-owl-carousel-o) library for implementing the carousel. I'm leaving the final decision on including it in the package.json on the main branch for further consideration.

Additionally, this PR adds a missing translation for the Related Articles title and ensures proper accessibility for the carousel navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Carousel-based Related Articles section with previous/next slide navigation
  * Localized labels for related-articles UI (English and Polish)

* **Improvements**
  * Carousel styles integrated for consistent appearance
  * Related-articles fetch limited to up to 4 items for concise display
  * Avatar sizing now uses explicit pixel dimensions for predictable rendering
<!-- end of auto-generated comment: release notes by coderabbit.ai -->