### PR TITLE
fix: remove trailing slash from canonical link and sitemap

### DIFF
--- a/apps/blog-analog/src/server/routes/api/sitemap.xml.ts
+++ b/apps/blog-analog/src/server/routes/api/sitemap.xml.ts
@@ -63,8 +63,9 @@ export default defineEventHandler(async (event) => {
 
   for (const lang of ['en', 'pl'] as const) {
     for (const path of STATIC_PATHS) {
+      const suffix = path ? `/${path}` : '';
       const loc =
-        lang === 'en' ? `${BASE_URL}/${path}` : `${BASE_URL}/pl/${path}`;
+        lang === 'en' ? `${BASE_URL}${suffix}` : `${BASE_URL}/pl${suffix}`;
 
       entries.push({
         loc,

--- a/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
@@ -311,6 +311,7 @@ export class SeoService {
 
   private getUrl(origin: string, path: string): string {
     const _url = new URL(`${origin}${path}`);
-    return `${_url.origin}${_url.pathname}`;
+    const pathname = _url.pathname.replace(/\/$/, '');
+    return `${_url.origin}${pathname}`;
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL formatting in sitemaps to eliminate unnecessary slashes in language-specific routes.
  * Improved URL normalization by removing trailing slashes from generated paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HouseOfAngular/angular-love/pull/519)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->