### PR TITLE
fix: interceptors order in analog ssr

### DIFF
--- a/apps/blog-analog/src/app/app.config.ts
+++ b/apps/blog-analog/src/app/app.config.ts
@@ -29,6 +29,7 @@ import { provideFastSVG } from '@push-based/ngx-fast-svg';
 import { NGX_SKELETON_LOADER_CONFIG } from 'ngx-skeleton-loader';
 import { map, switchMap } from 'rxjs';
 
+import { i18nHeadersInterceptor } from '@angular-love/blog/i18n/data-access';
 import { blogShellRoutes } from '@angular-love/blog/shell/feature';
 import { provideSeo } from '@angular-love/seo';
 import { ConfigService, provideConfig } from '@angular-love/shared/config';
@@ -130,7 +131,7 @@ export const appConfig: ApplicationConfig = {
     },
     provideHttpClient(
       withFetch(),
-      withInterceptors([appRequestContextInterceptor]),
+      withInterceptors([i18nHeadersInterceptor, appRequestContextInterceptor]),
       withInterceptorsFromDi(),
     ),
     provideAppSeo(),

--- a/apps/blog-analog/src/app/i18n/provider.ts
+++ b/apps/blog-analog/src/app/i18n/provider.ts
@@ -1,13 +1,9 @@
 import { registerLocaleData } from '@angular/common';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import localePl from '@angular/common/locales/pl';
 import { isDevMode, LOCALE_ID } from '@angular/core';
 import { provideTransloco } from '@jsverse/transloco';
 
-import {
-  I18nHeadersInterceptor,
-  LocaleIdProvider,
-} from '@angular-love/blog/i18n/data-access';
+import { LocaleIdProvider } from '@angular-love/blog/i18n/data-access';
 import { AlI18nService, AlLocalizeService } from '@angular-love/blog/i18n/util';
 
 import { TranslocoAnalogLoader } from './loader';
@@ -26,11 +22,6 @@ export const provideAnalogI18n = () => {
       },
       loader: TranslocoAnalogLoader,
     }),
-    {
-      provide: HTTP_INTERCEPTORS,
-      useClass: I18nHeadersInterceptor,
-      multi: true,
-    },
     { provide: LOCALE_ID, useClass: LocaleIdProvider },
     AlLocalizeService,
     AlI18nService,

--- a/libs/blog/i18n/data-access/src/lib/i18n-headers.interceptor.ts
+++ b/libs/blog/i18n/data-access/src/lib/i18n-headers.interceptor.ts
@@ -2,6 +2,7 @@ import {
   HttpEvent,
   HttpHandler,
   HttpInterceptor,
+  HttpInterceptorFn,
   HttpRequest,
 } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
@@ -18,8 +19,19 @@ export class I18nHeadersInterceptor implements HttpInterceptor {
   ): Observable<HttpEvent<unknown>> {
     const LANG = this.translocoService.getActiveLang();
     const modifiedRequest = request.clone({
-      headers: request.headers.append('x-al-lang', LANG),
+      headers: request.headers.set('x-al-lang', LANG),
     });
     return next.handle(modifiedRequest);
   }
 }
+
+export const i18nHeadersInterceptor: HttpInterceptorFn = (request, next) => {
+  const translocoService = inject(TranslocoService);
+  const LANG = translocoService.getActiveLang();
+
+  const modifiedRequest = request.clone({
+    headers: request.headers.set('x-al-lang', LANG),
+  });
+
+  return next(modifiedRequest);
+};


### PR DESCRIPTION
Analog's request context interceptor run before interceptors from DI, therefore it does not append language headers from `I18nHeadersInterceptor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized registration of the internationalization HTTP header handler into the HTTP client interceptor chain.
* **Behavior Change**
  * Outbound requests now send a single language header value (new value replaces any existing one) instead of appending multiple values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/HouseOfAngular/angular-love/pull/534?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->