### PR TITLE
fix: rss titles

### DIFF
--- a/apps/blog-analog/src/server/routes/feed-pl.xml.get.ts
+++ b/apps/blog-analog/src/server/routes/feed-pl.xml.get.ts
@@ -72,6 +72,7 @@ export default defineEventHandler(async (event) => {
   let xml: string;
   try {
     xml = buildRssFeed(articleRows, {
+      title: 'Angular.love Blog (PL)',
       channelLink: BASE_URL_PL,
       feedUrl: `${BASE_URL}/feed-pl.xml`,
       alternateFeedUrl: `${BASE_URL}/feed.xml`,

--- a/apps/blog-analog/src/server/routes/feed.xml.get.ts
+++ b/apps/blog-analog/src/server/routes/feed.xml.get.ts
@@ -71,6 +71,7 @@ export default defineEventHandler(async (event) => {
   let xml: string;
   try {
     xml = buildRssFeed(articleRows, {
+      title: 'Angular.love Blog (EN)',
       channelLink: BASE_URL,
       feedUrl: `${BASE_URL}/feed.xml`,
       alternateFeedUrl: `${BASE_URL}/feed-pl.xml`,

--- a/apps/blog-analog/src/server/utils/rss.ts
+++ b/apps/blog-analog/src/server/utils/rss.ts
@@ -13,6 +13,7 @@ export type FeedArticle = {
 };
 
 export type FeedConfig = {
+  title: string;
   channelLink: string;
   feedUrl: string;
   alternateFeedUrl: string;
@@ -38,7 +39,7 @@ export function buildRssFeed(
 
   channel
     .ele('title')
-    .txt('angular.love')
+    .txt(config.title)
     .up()
     .ele('link')
     .txt(config.channelLink)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * RSS feed titles are now properly configured with language-specific labels, ensuring correct feed identification in RSS readers for both English and Polish editions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->