### PR TITLE
fix: redirect on missing article translation

### DIFF
--- a/apps/blog-analog/src/app/i18n/assets/en.json
+++ b/apps/blog-analog/src/app/i18n/assets/en.json
@@ -36,7 +36,13 @@
     "languagePicker": {
       "pl": "Polish",
       "en": "English",
-      "select_lang": "Select language"
+      "select_lang": "Select language",
+      "noTranslationDialog": {
+        "title": "Translation not available",
+        "description": "This article hasn't been translated into {{lang}} yet.",
+        "stayButton": "Stay on this page",
+        "goHomeButton": "Go to homepage"
+      }
     }
   },
   "footer": {

--- a/apps/blog-analog/src/app/i18n/assets/pl.json
+++ b/apps/blog-analog/src/app/i18n/assets/pl.json
@@ -36,7 +36,13 @@
     "languagePicker": {
       "pl": "Polski",
       "en": "Angielski",
-      "select_lang": "Wybierz język"
+      "select_lang": "Wybierz język",
+      "noTranslationDialog": {
+        "title": "Tłumaczenie niedostępne",
+        "description": "Ten artykuł nie jest jeszcze dostępny w tym języku.",
+        "stayButton": "Zostań na tej stronie",
+        "goHomeButton": "Strona główna"
+      }
     }
   },
   "footer": {

--- a/apps/blog/src/assets/i18n/en.json
+++ b/apps/blog/src/assets/i18n/en.json
@@ -36,7 +36,13 @@
     "languagePicker": {
       "pl": "Polish",
       "en": "English",
-      "select_lang": "Select language"
+      "select_lang": "Select language",
+      "noTranslationDialog": {
+        "title": "Translation not available",
+        "description": "This article hasn't been translated into {{lang}} yet.",
+        "stayButton": "Stay on this page",
+        "goHomeButton": "Go to homepage"
+      }
     }
   },
   "footer": {

--- a/apps/blog/src/assets/i18n/pl.json
+++ b/apps/blog/src/assets/i18n/pl.json
@@ -36,7 +36,13 @@
     "languagePicker": {
       "pl": "Polski",
       "en": "Angielski",
-      "select_lang": "Wybierz język"
+      "select_lang": "Wybierz język",
+      "noTranslationDialog": {
+        "title": "Tłumaczenie niedostępne",
+        "description": "Ten artykuł nie jest jeszcze dostępny w tym języku.",
+        "stayButton": "Zostań na tej stronie",
+        "goHomeButton": "Strona główna"
+      }
     }
   },
   "footer": {

--- a/libs/blog/layouts/ui-navigation/src/lib/language-picker/language-picker.component.ts
+++ b/libs/blog/layouts/ui-navigation/src/lib/language-picker/language-picker.component.ts
@@ -1,8 +1,10 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   input,
   output,
+  viewChild,
 } from '@angular/core';
 import { TranslocoPipe } from '@jsverse/transloco';
 import { FastSvgComponent } from '@push-based/ngx-fast-svg';
@@ -30,9 +32,9 @@ import { Lang } from '@angular-love/contracts/articles';
 
         <select
           id="language-picker"
-          #selectLang
+          #selectEl
           class="bg-al-background appearance-none rounded-md px-8 py-1"
-          (change)="languageChange.emit(selectLang.value)"
+          (change)="onSelectionChange(selectEl.value)"
         >
           @for (lang of availableLangs; track $index) {
             <option [selected]="lang.value === language()" [value]="lang.value">
@@ -54,6 +56,9 @@ import { Lang } from '@angular-love/contracts/articles';
   imports: [FastSvgComponent, TranslocoPipe],
 })
 export class LanguagePickerComponent {
+  private readonly _selectEl =
+    viewChild.required<ElementRef<HTMLSelectElement>>('selectEl');
+
   readonly language = input.required<string>();
 
   readonly languageChange = output<string>();
@@ -64,4 +69,14 @@ export class LanguagePickerComponent {
     { value: 'en', translationPath: `${this.baseTranslationPath}.en` },
     { value: 'pl', translationPath: `${this.baseTranslationPath}.pl` },
   ] satisfies { value: Lang; translationPath: string }[];
+
+  protected onSelectionChange(value: string): void {
+    this.languageChange.emit(value);
+    // If the parent doesn't confirm the switch (e.g. shows a dialog instead of
+    // navigating), language() stays at the old value. Schedule a reset so the
+    // select snaps back after any parent-side effects have had a chance to run.
+    setTimeout(() => {
+      this._selectEl().nativeElement.value = this.language();
+    });
+  }
 }

--- a/libs/blog/search/feature-search/src/lib/feature-search/global-search.service.ts
+++ b/libs/blog/search/feature-search/src/lib/feature-search/global-search.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, signal } from '@angular/core';
 
+import '@angular/cdk/dialog';
+
 @Injectable()
 export class GlobalSearchService {
   private readonly _isSearchOpen = signal<boolean>(false);

--- a/libs/blog/shell/feature-shell-web/src/lib/article-no-translation-dialog.component.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/article-no-translation-dialog.component.ts
@@ -1,0 +1,46 @@
+import { DIALOG_DATA, DialogRef } from '@angular/cdk/dialog';
+import { Component, inject } from '@angular/core';
+import { TranslocoDirective } from '@jsverse/transloco';
+
+import { ButtonComponent } from '@angular-love/blog/shared/ui-button';
+
+export interface ArticleNoTranslationDialogData {
+  targetLang: string;
+  targetLangName: string;
+}
+
+export type ArticleNoTranslationDialogResult = 'home' | null;
+
+@Component({
+  selector: 'al-article-no-translation-dialog',
+  imports: [TranslocoDirective, ButtonComponent],
+  template: `
+    <div
+      *transloco="let t; read: 'nav.languagePicker.noTranslationDialog'"
+      class="bg-al-background flex max-w-md flex-col gap-6 rounded-xl p-8 shadow-xl"
+    >
+      <h2 class="text-xl font-bold">{{ t('title') }}</h2>
+      <p class="text-al-muted-foreground">
+        {{ t('description', { lang: data.targetLangName }) }}
+      </p>
+      <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <button al-button (click)="close(null)" variant="Secondary">
+          {{ t('stayButton') }}
+        </button>
+        <button al-button (click)="close('home')">
+          {{ t('goHomeButton') }}
+        </button>
+      </div>
+    </div>
+  `,
+})
+export class ArticleNoTranslationDialogComponent {
+  protected readonly data = inject<ArticleNoTranslationDialogData>(DIALOG_DATA);
+
+  private readonly _dialogRef =
+    inject<DialogRef<ArticleNoTranslationDialogResult>>(DialogRef);
+
+  close(result: ArticleNoTranslationDialogResult): void {
+    this._dialogRef.close(result);
+  }
+}

--- a/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/root-shell.component.ts
@@ -1,3 +1,4 @@
+import { Dialog } from '@angular/cdk/dialog';
 import { ViewportScroller } from '@angular/common';
 import { Component, computed, effect, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -8,9 +9,10 @@ import {
   RouterOutlet,
 } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
-import { filter, map, startWith, switchMap } from 'rxjs';
+import { filter, map, startWith, switchMap, take } from 'rxjs';
 
 import { AdBannerStore } from '@angular-love/blog/ad-banner/data-access';
+import { ArticleDetailsStore } from '@angular-love/blog/articles/data-access';
 import { AlLocalizeService } from '@angular-love/blog/i18n/util';
 import {
   FooterComponent,
@@ -24,6 +26,11 @@ import {
   AlBannerCarouselComponent,
 } from '@angular-love/blog/shared/ad-banner';
 import { AppThemeStore } from '@angular-love/data-access-app-theme';
+
+import {
+  ArticleNoTranslationDialogComponent,
+  ArticleNoTranslationDialogResult,
+} from './article-no-translation-dialog.component';
 
 const FOOTERLESS_ROUTES = ['roadmap'];
 
@@ -79,6 +86,8 @@ export class RootShellComponent {
   private readonly _router = inject(Router);
   private readonly _localizeService = inject(AlLocalizeService);
   private readonly _activatedRoute = inject(ActivatedRoute);
+  private readonly _dialog = inject(Dialog);
+  private readonly _articleDetailsStore = inject(ArticleDetailsStore);
 
   protected readonly sliderStore = inject(AdBannerStore);
   protected readonly slides = computed<AdImageBanner[] | undefined>(() =>
@@ -129,7 +138,43 @@ export class RootShellComponent {
     ),
   );
 
-  onLanguageChange(lang: string) {
+  onLanguageChange(lang: string): void {
+    const article = this._articleDetailsStore.articleDetails();
+    const urlPath = this._router.url.split('?')[0];
+    const isOnArticlePage =
+      !!article &&
+      (urlPath === `/${article.slug}` || urlPath === `/pl/${article.slug}`);
+
+    if (isOnArticlePage) {
+      const hasTranslation = article.otherTranslations.some((t) =>
+        t.locale.includes(lang),
+      );
+
+      if (!hasTranslation) {
+        const targetLangName = this.translocoService.translate(
+          `nav.languagePicker.${lang}`,
+        );
+
+        const dialogRef = this._dialog.open<
+          ArticleNoTranslationDialogResult,
+          { targetLang: string; targetLangName: string },
+          ArticleNoTranslationDialogComponent
+        >(ArticleNoTranslationDialogComponent, {
+          data: { targetLang: lang, targetLangName },
+          backdropClass: ['backdrop-blur-sm'],
+        });
+
+        dialogRef.closed.pipe(take(1)).subscribe((result) => {
+          if (result === 'home') {
+            this._router.navigateByUrl(
+              this._localizeService.localizeExplicitPath('/', lang),
+            );
+          }
+        });
+        return;
+      }
+    }
+
     this._router.navigateByUrl(
       this._localizeService.localizeExplicitPath(this._router.url, lang),
     );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dialog that appears when users attempt to switch to a language without an available article translation, allowing them to stay on the current page or return home.
  * Improved language picker behavior to reset the selection if the language change isn't confirmed by the parent component.

* **Documentation**
  * Added translation strings for the new unavailable translation dialog in English and Polish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->