### PR TITLE
fix(videos): lower video card button z-index to prevent overlapping header

### DIFF
--- a/libs/blog/videos/ui-video-card/src/lib/components/video-card/video-card.component.html
+++ b/libs/blog/videos/ui-video-card/src/lib/components/video-card/video-card.component.html
@@ -3,7 +3,7 @@
 >
   <button
     type="button"
-    class="absolute inset-0 z-20 cursor-pointer rounded-lg"
+    class="absolute inset-0 z-[1] cursor-pointer rounded-lg"
     [attr.aria-label]="videoPlayerTitle() + ': ' + video().title"
     (click)="playVideo.emit()"
   ></button>


### PR DESCRIPTION
The card's play button used z-20 which promoted into the root stacking context and out-ranked the sticky header wrapper (z-10), so clicks on the header landed on the card button instead if the button was directly below it. Lower it to z-1, which still sits above the card's z-0 gradient overlay but no longer competes with the header.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the video card’s overlay stacking order so card content and controls display correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->