### PR TITLE
feat: add schema org on homepage

### DIFF
--- a/apps/blog-analog/src/app/i18n/assets/en.json
+++ b/apps/blog-analog/src/app/i18n/assets/en.json
@@ -212,6 +212,7 @@
   },
   "seo": {
     "metaDescription": "Angular.love - a place for all Angular enthusiasts created to inspire and educate.",
+    "breadcrumbHome": "Home",
     "home": "Blog and community for Angular fans",
     "aboutUs": "About us",
     "becomeAuthor": "Become an author",

--- a/apps/blog-analog/src/app/i18n/assets/pl.json
+++ b/apps/blog-analog/src/app/i18n/assets/pl.json
@@ -215,6 +215,7 @@
   },
   "seo": {
     "metaDescription": "Angular.love - ciekawostki oraz rozwiązania dla średnio-zaawansowanych oraz zaawansowanych developerów Angulara.",
+    "breadcrumbHome": "Strona główna",
     "home": "Blog dla sympatyków Angulara",
     "aboutUs": "O nas",
     "becomeAuthor": "Zostań autorem",

--- a/apps/blog-analog/src/server/routes/api/articles/[slug].get.ts
+++ b/apps/blog-analog/src/server/routes/api/articles/[slug].get.ts
@@ -18,6 +18,7 @@ export default defineEventHandler(async (event) => {
       content: articles.content,
       slug: articles.slug,
       title: articles.title,
+      excerpt: articles.excerpt,
       readingTime: articles.readingTime,
       publishDate: articles.publishDate,
       difficulty: articles.difficulty,

--- a/apps/blog/src/assets/i18n/en.json
+++ b/apps/blog/src/assets/i18n/en.json
@@ -213,6 +213,7 @@
   },
   "seo": {
     "metaDescription": "Angular.love - a place for all Angular enthusiasts created to inspire and educate.",
+    "breadcrumbHome": "Home",
     "home": "Blog and community for Angular fans",
     "aboutUs": "About us",
     "becomeAuthor": "Become an author",

--- a/apps/blog/src/assets/i18n/pl.json
+++ b/apps/blog/src/assets/i18n/pl.json
@@ -216,6 +216,7 @@
   },
   "seo": {
     "metaDescription": "Angular.love - ciekawostki oraz rozwiązania dla średnio-zaawansowanych oraz zaawansowanych developerów Angulara.",
+    "breadcrumbHome": "Strona główna",
     "home": "Blog dla sympatyków Angulara",
     "aboutUs": "O nas",
     "becomeAuthor": "Zostań autorem",

--- a/libs/blog-bff/articles/api/src/lib/api.ts
+++ b/libs/blog-bff/articles/api/src/lib/api.ts
@@ -95,6 +95,7 @@ app.get('/:slug', async (c) => {
       content: articles.content,
       slug: articles.slug,
       title: articles.title,
+      excerpt: articles.excerpt,
       readingTime: articles.readingTime,
       publishDate: articles.publishDate,
       difficulty: articles.difficulty,

--- a/libs/blog-bff/articles/api/src/lib/dtos.ts
+++ b/libs/blog-bff/articles/api/src/lib/dtos.ts
@@ -1,7 +1,10 @@
 import { AuthorTitle } from '@angular-love/blog/contracts/authors';
 
 export interface WPPostDto {
+  /** Site-local wall clock, no offset — do not treat as UTC. Use `date_gmt`. */
   date: string;
+  /** True UTC instant, no offset suffix (WP omits the trailing `Z`). */
+  date_gmt: string;
   slug: string;
   featured_image_url: string;
   title: {

--- a/libs/blog-bff/articles/api/src/lib/mappers.ts
+++ b/libs/blog-bff/articles/api/src/lib/mappers.ts
@@ -4,6 +4,17 @@ import { ArticlePreview } from '@angular-love/contracts/articles';
 
 import { WPPostDto } from './dtos';
 
+/**
+ * WP's `date` is the site-local wall clock with no offset, so parsing it yields
+ * an instant shifted by the site's timezone (2h in summer for Europe/Warsaw).
+ * `date_gmt` is the real UTC instant but also carries no suffix, so it needs an
+ * explicit `Z` before parsing.
+ */
+const toPublishDateIso = (dto: WPPostDto): string => {
+  const utc = dto.date_gmt ? `${dto.date_gmt}Z` : dto.date;
+  return new Date(utc || '').toISOString();
+};
+
 export const toArticlePreviewList = (dtos: WPPostDto[]): ArticlePreview[] => {
   return (dtos || []).map((dto) => {
     const summary = cheerio.load(dto.excerpt.rendered || '');
@@ -14,7 +25,7 @@ export const toArticlePreviewList = (dtos: WPPostDto[]): ArticlePreview[] => {
       title: title.text(),
       excerpt: summary.text(),
       featuredImageUrl: dto.featured_image_url || null,
-      publishDate: new Date(dto.date || '').toISOString(),
+      publishDate: toPublishDateIso(dto),
       readingTime: dto.acf?.reading_time?.toString() || '5',
       difficulty: dto.acf?.difficulty || 'intermediate',
       author: {

--- a/libs/blog-bff/articles/api/src/lib/wp-posts.ts
+++ b/libs/blog-bff/articles/api/src/lib/wp-posts.ts
@@ -12,7 +12,7 @@ export class WpPosts {
       ...query,
       status: 'publish',
       _fields:
-        'id,type,slug,title.rendered,author,excerpt.rendered,date,featured_image_url,author_details.name,author_details.avatar_url,author_details.slug,acf',
+        'id,type,slug,title.rendered,author,excerpt.rendered,date,date_gmt,featured_image_url,author_details.name,author_details.avatar_url,author_details.slug,acf',
     });
   }
 
@@ -24,7 +24,7 @@ export class WpPosts {
       ...query,
       status: 'publish',
       _fields:
-        'id,type,slug,title.rendered,author,excerpt.rendered,date,featured_image_url,author_details.name,author_details.avatar_url,author_details.slug,acf',
+        'id,type,slug,title.rendered,author,excerpt.rendered,date,date_gmt,featured_image_url,author_details.name,author_details.avatar_url,author_details.slug,acf',
     });
   }
 
@@ -41,6 +41,7 @@ export class WpPosts {
       'og_url',
       'og_site_name',
       'article_publisher',
+      'article_published_time',
       'article_modified_time',
       'og_image',
       'twitter_card',

--- a/libs/blog-contracts/articles/src/lib/articles.ts
+++ b/libs/blog-contracts/articles/src/lib/articles.ts
@@ -110,6 +110,11 @@ export interface Article {
   title: string;
   slug: string;
   content: string;
+  /**
+   * Per-article summary from WP. Preferred over `seo.description`, which holds
+   * the site-wide Yoast default because per-post descriptions are not maintained.
+   */
+  excerpt: string;
   publishDate: string;
   readingTime: string;
   difficulty: 'beginner' | 'intermediate' | 'advanced';

--- a/libs/blog/articles/feature-article/src/lib/article-details/article-details.stories.ts
+++ b/libs/blog/articles/feature-article/src/lib/article-details/article-details.stories.ts
@@ -3,7 +3,7 @@ import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 
 import { TranslocoHttpLoader } from '@angular-love/blog/i18n/data-access';
 import { AlLocalizeService } from '@angular-love/blog/i18n/util';
-import { Article, SeoData } from '@angular-love/contracts/articles';
+import { Article, DbLang, SeoData } from '@angular-love/contracts/articles';
 import { ConfigService } from '@angular-love/shared/config';
 
 import { ArticleDetailsComponent } from './article-details.component';
@@ -35,9 +35,11 @@ const articleDetails: Article = {
   slug: '',
   seo: {} as SeoData,
   otherTranslations: {} as any,
-  lang: 'en',
+  language: DbLang.English,
   readingTime: '3',
   title: "Why Angular signals won't replace RxJs",
+  excerpt:
+    'Signals will not replace RxJs — they cover the synchronous half of the problem.',
   difficulty: 'beginner',
   author: {
     slug: '',

--- a/libs/blog/shared/util-seo/src/lib/json-ld/description.spec.ts
+++ b/libs/blog/shared/util-seo/src/lib/json-ld/description.spec.ts
@@ -1,0 +1,48 @@
+import { normalizeSeoDescription } from './description';
+
+describe('normalizeSeoDescription', () => {
+  it('returns an empty string for missing input', () => {
+    expect(normalizeSeoDescription(undefined)).toBe('');
+    expect(normalizeSeoDescription('')).toBe('');
+  });
+
+  it('strips markup', () => {
+    expect(normalizeSeoDescription('<p>Hello <strong>world</strong></p>')).toBe(
+      'Hello world',
+    );
+  });
+
+  it('decodes the entities WP renders', () => {
+    expect(
+      normalizeSeoDescription('Zod &amp; Angular &ndash; part&nbsp;2 &hellip;'),
+    ).toBe('Zod & Angular – part 2 …');
+  });
+
+  it('collapses the NBSP and trailing newline WP leaves behind', () => {
+    expect(normalizeSeoDescription('Recap: where we left off \n')).toBe(
+      'Recap: where we left off',
+    );
+  });
+
+  it('cannot be tricked into forming a tag by encoded markup', () => {
+    const out = normalizeSeoDescription(
+      '&lt;script&gt;alert(1)&lt;/script&gt;',
+    );
+    expect(out).toBe('<script>alert(1)</script>');
+    // Decoded to text only — no tag was stripped after decoding, so nothing
+    // downstream sees markup it did not already escape.
+    expect(normalizeSeoDescription('<script>alert(1)</script>')).toBe(
+      'alert(1)',
+    );
+  });
+
+  it('drops unknown entities rather than leaving raw markup', () => {
+    expect(normalizeSeoDescription('a &weird; b')).toBe('a b');
+  });
+
+  it('preserves ordinary punctuation and accents', () => {
+    expect(
+      normalizeSeoDescription('Mateusz Stefańczyk — "WebMCP", part 1'),
+    ).toBe('Mateusz Stefańczyk — "WebMCP", part 1');
+  });
+});

--- a/libs/blog/shared/util-seo/src/lib/json-ld/description.ts
+++ b/libs/blog/shared/util-seo/src/lib/json-ld/description.ts
@@ -1,0 +1,39 @@
+/**
+ * WP excerpts arrive as rendered HTML fragments — tags, entities, non-breaking
+ * spaces and a trailing newline. Flatten one into plain text fit for a meta
+ * description / JSON-LD `description`.
+ *
+ * Lives next to `url-rewrite` because, like it, both the meta layer and the
+ * JSON-LD builders need it.
+ */
+const NAMED_ENTITIES: Record<string, string> = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&apos;': "'",
+  '&#039;': "'",
+  '&nbsp;': ' ',
+  '&hellip;': '…',
+  '&mdash;': '—',
+  '&ndash;': '–',
+};
+
+export function normalizeSeoDescription(raw: string | undefined): string {
+  if (!raw) {
+    return '';
+  }
+
+  return (
+    raw
+      // Strip markup first, so decoded entities can never form a tag.
+      .replace(/<[^>]*>/g, ' ')
+      .replace(
+        /&[a-z]+;|&#\d+;/gi,
+        (entity) => NAMED_ENTITIES[entity.toLowerCase()] ?? ' ',
+      )
+      // \s covers the NBSP and trailing newline WP leaves behind.
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}

--- a/libs/blog/shared/util-seo/src/lib/json-ld/index.ts
+++ b/libs/blog/shared/util-seo/src/lib/json-ld/index.ts
@@ -1,3 +1,4 @@
+export * from './description';
 export * from './json-ld.builders';
 export * from './json-ld.types';
 export * from './url-rewrite';

--- a/libs/blog/shared/util-seo/src/lib/json-ld/json-ld.builders.spec.ts
+++ b/libs/blog/shared/util-seo/src/lib/json-ld/json-ld.builders.spec.ts
@@ -5,10 +5,12 @@ import {
   buildBreadcrumbList,
   buildHomeBreadcrumb,
   buildOrganization,
+  buildOrganizationId,
   buildPageGraph,
   buildPerson,
   buildPersonId,
   buildWebPage,
+  buildWebPageId,
   buildWebSite,
   serializeJsonLd,
 } from './json-ld.builders';
@@ -17,6 +19,8 @@ import { SchemaGraphEntity, SchemaWebPage } from './json-ld.types';
 const BASE_URL = 'https://angular.love';
 const SITE_NAME = 'Angular.love';
 const IN_LANGUAGE = ['en', 'pl'];
+const HOME = { name: 'Home', url: `${BASE_URL}/` };
+const HOME_PL = { name: 'Strona główna', url: `${BASE_URL}/pl` };
 
 const makeAuthor = (
   overrides: Partial<{
@@ -43,6 +47,8 @@ const makeArticle = (
     title: string;
     slug: string;
     language: DbLang;
+    publishDate: string;
+    excerpt: string;
     seo: Record<string, unknown>;
     author: ReturnType<typeof makeAuthor>;
   }> = {},
@@ -51,6 +57,7 @@ const makeArticle = (
   title: 'Understanding Signals',
   slug: 'understanding-signals',
   content: '<p>content</p>',
+  excerpt: 'A deep dive into Angular signals.',
   publishDate: '2025-01-01',
   readingTime: '5 min',
   difficulty: 'intermediate' as const,
@@ -188,7 +195,45 @@ describe('buildBlogPosting', () => {
     });
     expect(posting['@id']).toBe(`${plUrl}#article`);
     expect(posting.url).toBe(plUrl);
-    expect(posting.mainEntityOfPage).toEqual({ '@id': plUrl });
+    expect(posting.mainEntityOfPage).toEqual({ '@id': `${plUrl}#webpage` });
+  });
+
+  it('points mainEntityOfPage at the WebPage entity, not the bare page URL', () => {
+    const posting = buildBlogPosting(makeArticle(), {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.mainEntityOfPage).toEqual({
+      '@id': buildWebPageId(PAGE_URL),
+    });
+  });
+
+  it('falls back to article.publishDate when Yoast omits the published time', () => {
+    const article = makeArticle({
+      seo: { article_modified_time: '2026-02-01T10:00:00Z' },
+      publishDate: '2026-01-01T08:00:00.000Z',
+    });
+    const posting = buildBlogPosting(article, {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.datePublished).toBe('2026-01-01T08:00:00.000Z');
+    expect(posting.dateModified).toBe('2026-02-01T10:00:00Z');
+  });
+
+  it('prefers the Yoast published time over article.publishDate', () => {
+    const article = makeArticle({
+      seo: { article_published_time: '2025-01-01T10:00:00Z' },
+      publishDate: '2026-01-01T08:00:00.000Z',
+    });
+    const posting = buildBlogPosting(article, {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.datePublished).toBe('2025-01-01T10:00:00Z');
   });
 
   it('references author by @id, not by inline object', () => {
@@ -215,9 +260,54 @@ describe('buildBlogPosting', () => {
     });
   });
 
+  it('takes description from the excerpt, never from Yoast seo.description', () => {
+    const article = makeArticle({
+      excerpt: 'What signals actually change about change detection.',
+      // The site-wide Yoast default, in the wrong language — must not be used.
+      seo: {
+        description:
+          'Angular.love - ciekawostki oraz rozwiązania dla developerów.',
+      },
+    });
+    const posting = buildBlogPosting(article, {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.description).toBe(
+      'What signals actually change about change detection.',
+    );
+  });
+
+  it('flattens a rendered-HTML excerpt into the description', () => {
+    const article = makeArticle({
+      excerpt: '<p>Signals&nbsp;explained &amp; demystified &hellip;</p>\n',
+    });
+    const posting = buildBlogPosting(article, {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.description).toBe('Signals explained & demystified …');
+  });
+
+  it('omits description when the excerpt is empty', () => {
+    const article = makeArticle({
+      excerpt: '',
+      seo: { description: 'the Yoast default that must not leak in' },
+    });
+    const posting = buildBlogPosting(article, {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.description).toBeUndefined();
+  });
+
   it('omits optional fields when seo data is absent', () => {
     const article = makeArticle({
       seo: {},
+      excerpt: '',
     });
     const posting = buildBlogPosting(article, {
       pageUrl: PAGE_URL,
@@ -226,8 +316,19 @@ describe('buildBlogPosting', () => {
     });
     expect(posting.description).toBeUndefined();
     expect(posting.image).toBeUndefined();
-    expect(posting.datePublished).toBeUndefined();
     expect(posting.dateModified).toBeUndefined();
+    // datePublished still resolves — it falls back to article.publishDate.
+    expect(posting.datePublished).toBe('2025-01-01');
+  });
+
+  it('omits datePublished only when both seo and publishDate are empty', () => {
+    const article = makeArticle({ seo: {}, publishDate: '' });
+    const posting = buildBlogPosting(article, {
+      pageUrl: PAGE_URL,
+      baseUrl: BASE_URL,
+      inLanguage: 'en',
+    });
+    expect(posting.datePublished).toBeUndefined();
   });
 });
 
@@ -390,6 +491,50 @@ describe('buildWebPage', () => {
       expect(page.inLanguage).toBe(inLanguage);
     },
   );
+
+  it('omits description, mainEntity and about when no options are passed', () => {
+    const page = buildWebPage(
+      'WebPage',
+      `${BASE_URL}/test#webpage`,
+      `${BASE_URL}/test`,
+      'Test',
+      'en',
+      BASE_URL,
+    );
+    expect(page.description).toBeUndefined();
+    expect(page.mainEntity).toBeUndefined();
+    expect(page.about).toBeUndefined();
+  });
+
+  it('emits description and about when provided', () => {
+    const page = buildWebPage(
+      'WebPage',
+      `${BASE_URL}/test#webpage`,
+      `${BASE_URL}/test`,
+      'Test',
+      'en',
+      BASE_URL,
+      {
+        description: 'A page about things',
+        about: { '@id': buildOrganizationId(BASE_URL) },
+      },
+    );
+    expect(page.description).toBe('A page about things');
+    expect(page.about).toEqual({ '@id': 'https://angular.love/#organization' });
+  });
+
+  it('omits an empty description rather than emitting a blank string', () => {
+    const page = buildWebPage(
+      'WebPage',
+      `${BASE_URL}/test#webpage`,
+      `${BASE_URL}/test`,
+      'Test',
+      'en',
+      BASE_URL,
+      { description: '' },
+    );
+    expect(page.description).toBeUndefined();
+  });
 });
 
 describe('serializeJsonLd', () => {
@@ -424,7 +569,7 @@ describe('buildHomeBreadcrumb', () => {
   const crumb = buildHomeBreadcrumb(
     `${BASE_URL}/news#breadcrumb`,
     { name: 'News', url: `${BASE_URL}/news` },
-    BASE_URL,
+    HOME,
   );
 
   it('prepends a Home item pointing at baseUrl/', () => {
@@ -433,6 +578,22 @@ describe('buildHomeBreadcrumb', () => {
       position: 1,
       name: 'Home',
       item: `${BASE_URL}/`,
+    });
+  });
+
+  it('uses the localized root crumb on a non-default-language page', () => {
+    const plCrumb = buildHomeBreadcrumb(
+      `${BASE_URL}/pl/artykul#breadcrumb`,
+      { name: 'Artykuł', url: `${BASE_URL}/pl/artykul` },
+      HOME_PL,
+    );
+    // Was 'Home' → https://angular.love/ on Polish pages: English label
+    // pointing at the English site root.
+    expect(plCrumb.itemListElement[0]).toEqual({
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Strona główna',
+      item: `${BASE_URL}/pl`,
     });
   });
 
@@ -483,13 +644,13 @@ describe('Author profile graph (ProfilePage + Person + BreadcrumbList)', () => {
       author.name,
       'en',
       BASE_URL,
-      { '@id': `${PAGE_URL}#person` },
+      { mainEntity: { '@id': `${PAGE_URL}#person` } },
     );
     const person = buildPerson(author, { baseUrl: BASE_URL });
     const breadcrumb = buildHomeBreadcrumb(
       `${PAGE_URL}#breadcrumb`,
       { name: author.name, url: PAGE_URL },
-      BASE_URL,
+      HOME,
     );
     const graph = [profilePage, person, breadcrumb];
 
@@ -528,7 +689,7 @@ describe('Author profile graph (ProfilePage + Person + BreadcrumbList)', () => {
     const breadcrumb = buildHomeBreadcrumb(
       `${PAGE_URL}#breadcrumb`,
       { name: 'Jane Dev', url: PAGE_URL },
-      BASE_URL,
+      HOME,
     );
     expect(breadcrumb.itemListElement[0]).toMatchObject({
       '@type': 'ListItem',
@@ -552,6 +713,7 @@ describe('buildPageGraph', () => {
       baseUrl: BASE_URL,
       name: 'About us',
       inLanguage: 'en',
+      home: HOME,
     });
     expect(graph).toHaveLength(1);
     expect(graph[0]).toMatchObject({
@@ -562,6 +724,46 @@ describe('buildPageGraph', () => {
     expect((graph[0] as SchemaWebPage).mainEntity).toBeUndefined();
   });
 
+  it('forwards description onto the page entity', () => {
+    const graph = buildPageGraph({
+      jsonLdType: 'AboutPage',
+      url: `${BASE_URL}/about-us`,
+      baseUrl: BASE_URL,
+      name: 'About us',
+      inLanguage: 'en',
+      home: HOME,
+      description: 'Who we are',
+    });
+    expect((graph[0] as SchemaWebPage).description).toBe('Who we are');
+  });
+
+  it('binds the page to the Organization when aboutOrganization is set', () => {
+    const graph = buildPageGraph({
+      jsonLdType: 'WebPage',
+      url: BASE_URL,
+      baseUrl: BASE_URL,
+      name: 'Blog and community for Angular fans',
+      inLanguage: 'en',
+      home: HOME,
+      aboutOrganization: true,
+    });
+    expect((graph[0] as SchemaWebPage).about).toEqual({
+      '@id': buildOrganizationId(BASE_URL),
+    });
+  });
+
+  it('omits about when aboutOrganization is not set', () => {
+    const graph = buildPageGraph({
+      jsonLdType: 'WebPage',
+      url: `${BASE_URL}/become-author`,
+      baseUrl: BASE_URL,
+      name: 'Become an author',
+      inLanguage: 'en',
+      home: HOME,
+    });
+    expect((graph[0] as SchemaWebPage).about).toBeUndefined();
+  });
+
   it('appends a (Home → collection) breadcrumb for CollectionPage', () => {
     const graph = buildPageGraph({
       jsonLdType: 'CollectionPage',
@@ -569,6 +771,7 @@ describe('buildPageGraph', () => {
       baseUrl: BASE_URL,
       name: 'Angular News',
       inLanguage: 'pl',
+      home: HOME,
     });
     expect(graph).toHaveLength(2);
     expect(graph[0]['@type']).toBe('CollectionPage');
@@ -576,5 +779,31 @@ describe('buildPageGraph', () => {
       '@type': 'BreadcrumbList',
       '@id': `${BASE_URL}/news#breadcrumb`,
     });
+  });
+
+  it('links the CollectionPage to its breadcrumb so it is not orphaned', () => {
+    const graph = buildPageGraph({
+      jsonLdType: 'CollectionPage',
+      url: `${BASE_URL}/news`,
+      baseUrl: BASE_URL,
+      name: 'Angular News',
+      inLanguage: 'pl',
+      home: HOME,
+    });
+    expect((graph[0] as SchemaWebPage).breadcrumb).toEqual({
+      '@id': graph[1]['@id'],
+    });
+  });
+
+  it('omits breadcrumb on page types that emit none', () => {
+    const graph = buildPageGraph({
+      jsonLdType: 'WebPage',
+      url: `${BASE_URL}/writing-rules`,
+      baseUrl: BASE_URL,
+      name: 'Writing rules',
+      inLanguage: 'en',
+      home: HOME,
+    });
+    expect((graph[0] as SchemaWebPage).breadcrumb).toBeUndefined();
   });
 });

--- a/libs/blog/shared/util-seo/src/lib/json-ld/json-ld.builders.ts
+++ b/libs/blog/shared/util-seo/src/lib/json-ld/json-ld.builders.ts
@@ -1,5 +1,6 @@
 import { Article } from '@angular-love/contracts/articles';
 
+import { normalizeSeoDescription } from './description';
 import {
   SchemaBlogPosting,
   SchemaBreadcrumbList,
@@ -31,10 +32,14 @@ export interface BlogPostingContext {
   inLanguage: string;
 }
 
+export function buildOrganizationId(baseUrl: string): string {
+  return `${baseUrl}/#organization`;
+}
+
 export function buildOrganization(ctx: OrgContext): SchemaOrganization {
   return {
     '@type': 'Organization',
-    '@id': `${ctx.baseUrl}/#organization`,
+    '@id': buildOrganizationId(ctx.baseUrl),
     name: ctx.siteName,
     url: ctx.baseUrl,
     logo: {
@@ -59,7 +64,7 @@ export function buildWebSite(ctx: OrgContext): SchemaWebSite {
     url: `${ctx.baseUrl}/`,
     name: ctx.siteName,
     inLanguage: ctx.inLanguage,
-    publisher: { '@id': `${ctx.baseUrl}/#organization` },
+    publisher: { '@id': buildOrganizationId(ctx.baseUrl) },
     // TODO: verify the query param name used on the /search page (currently assuming ?q=)
     potentialAction: {
       '@type': 'SearchAction',
@@ -74,15 +79,20 @@ export function buildBlogPosting(
   ctx: BlogPostingContext,
 ): SchemaBlogPosting {
   const firstImage = article.seo.og_image?.[0];
+  // Yoast's article_published_time is absent from a lot of synced seo payloads;
+  // article.publishDate always carries the date, so fall back to it rather than
+  // emit a BlogPosting with only a dateModified.
+  const datePublished =
+    article.seo.article_published_time || article.publishDate;
+  // NOT seo.description — Yoast holds only the site-wide default there.
+  const description = normalizeSeoDescription(article.excerpt);
 
   return {
     '@type': 'BlogPosting',
     '@id': `${ctx.pageUrl}#article`,
     // article.title is what renders as <h1>; seo.title is the meta title (may differ)
     headline: article.title,
-    ...(article.seo.description
-      ? { description: article.seo.description }
-      : {}),
+    ...(description ? { description } : {}),
     ...(firstImage
       ? {
           image: {
@@ -93,17 +103,15 @@ export function buildBlogPosting(
           },
         }
       : {}),
-    ...(article.seo.article_published_time
-      ? { datePublished: article.seo.article_published_time }
-      : {}),
+    ...(datePublished ? { datePublished } : {}),
     ...(article.seo.article_modified_time
       ? { dateModified: article.seo.article_modified_time }
       : {}),
     inLanguage: ctx.inLanguage,
     url: ctx.pageUrl,
-    mainEntityOfPage: { '@id': ctx.pageUrl },
+    mainEntityOfPage: { '@id': buildWebPageId(ctx.pageUrl) },
     author: { '@id': buildPersonId(article.author.slug, ctx.baseUrl) },
-    publisher: { '@id': `${ctx.baseUrl}/#organization` },
+    publisher: { '@id': buildOrganizationId(ctx.baseUrl) },
   };
 }
 
@@ -172,6 +180,17 @@ export function buildBreadcrumbList(
   };
 }
 
+export interface WebPageOptions {
+  /** The page's primary content entity (e.g. the Person on a ProfilePage). */
+  mainEntity?: SchemaRef;
+  /** The entity the page is about (e.g. the Organization on the homepage). */
+  about?: SchemaRef;
+  /** Should match the page's meta description. */
+  description?: string;
+  /** The page's BreadcrumbList, which is otherwise orphaned in the graph. */
+  breadcrumb?: SchemaRef;
+}
+
 export function buildWebPage(
   type: WebPageType,
   pageId: string,
@@ -179,26 +198,45 @@ export function buildWebPage(
   name: string,
   inLanguage: string,
   baseUrl: string,
-  mainEntity?: SchemaRef,
+  opts: WebPageOptions = {},
 ): SchemaWebPage {
   return {
     '@type': type,
     '@id': pageId,
     url,
     name,
+    ...(opts.description ? { description: opts.description } : {}),
     inLanguage,
     isPartOf: { '@id': `${baseUrl}/#website` },
-    ...(mainEntity ? { mainEntity } : {}),
+    ...(opts.mainEntity ? { mainEntity: opts.mainEntity } : {}),
+    ...(opts.about ? { about: opts.about } : {}),
+    ...(opts.breadcrumb ? { breadcrumb: opts.breadcrumb } : {}),
   };
 }
 
-/** (Home → leaf) breadcrumb shared by article and collection page graphs. */
+/** `@id` of the WebPage entity for a page, and the `mainEntityOfPage` target. */
+export function buildWebPageId(pageUrl: string): string {
+  return `${pageUrl}#webpage`;
+}
+
+/** `@id` of a page's BreadcrumbList entity. */
+export function buildBreadcrumbId(pageUrl: string): string {
+  return `${pageUrl}#breadcrumb`;
+}
+
+/**
+ * (Home → leaf) breadcrumb shared by article and collection page graphs.
+ *
+ * `home` is passed in rather than derived from baseUrl: on a Polish page the
+ * crumb must be the Polish label pointing at the Polish home, not "Home"
+ * pointing at the English site root.
+ */
 export function buildHomeBreadcrumb(
   id: string,
   leaf: BreadcrumbItem,
-  baseUrl: string,
+  home: BreadcrumbItem,
 ): SchemaBreadcrumbList {
-  return buildBreadcrumbList(id, [{ name: 'Home', url: `${baseUrl}/` }, leaf]);
+  return buildBreadcrumbList(id, [home, leaf]);
 }
 
 export interface PageGraphContext {
@@ -207,6 +245,12 @@ export interface PageGraphContext {
   baseUrl: string;
   name: string;
   inLanguage: string;
+  /** Should match the page's meta description. */
+  description?: string;
+  /** Bind the page to the Organization entity via `about` (homepage). */
+  aboutOrganization?: boolean;
+  /** Localized (label + url) root crumb; used by CollectionPage. */
+  home: BreadcrumbItem;
 }
 
 /**
@@ -216,23 +260,31 @@ export interface PageGraphContext {
  * alone.
  */
 export function buildPageGraph(ctx: PageGraphContext): SchemaGraphEntity[] {
-  const pageId = `${ctx.url}#webpage`;
+  const isCollection = ctx.jsonLdType === 'CollectionPage';
+  const breadcrumbId = buildBreadcrumbId(ctx.url);
   const webPage = buildWebPage(
     ctx.jsonLdType,
-    pageId,
+    buildWebPageId(ctx.url),
     ctx.url,
     ctx.name,
     ctx.inLanguage,
     ctx.baseUrl,
+    {
+      description: ctx.description,
+      ...(ctx.aboutOrganization
+        ? { about: { '@id': buildOrganizationId(ctx.baseUrl) } }
+        : {}),
+      ...(isCollection ? { breadcrumb: { '@id': breadcrumbId } } : {}),
+    },
   );
 
-  if (ctx.jsonLdType === 'CollectionPage') {
+  if (isCollection) {
     return [
       webPage,
       buildHomeBreadcrumb(
-        `${ctx.url}#breadcrumb`,
+        breadcrumbId,
         { name: ctx.name, url: ctx.url },
-        ctx.baseUrl,
+        ctx.home,
       ),
     ];
   }

--- a/libs/blog/shared/util-seo/src/lib/json-ld/json-ld.types.ts
+++ b/libs/blog/shared/util-seo/src/lib/json-ld/json-ld.types.ts
@@ -92,9 +92,12 @@ export interface SchemaWebPage {
   '@id': string;
   url: string;
   name: string;
+  description?: string;
   inLanguage: string;
   isPartOf: SchemaRef;
   mainEntity?: SchemaRef;
+  about?: SchemaRef;
+  breadcrumb?: SchemaRef;
 }
 
 export type SchemaGraphEntity =

--- a/libs/blog/shared/util-seo/src/lib/providers/seo.provider.ts
+++ b/libs/blog/shared/util-seo/src/lib/providers/seo.provider.ts
@@ -27,9 +27,9 @@ export const provideSeo = (seoProvider: SeoProvider): EnvironmentProviders => {
     provideAppInitializer(() => {
       const initializerFn = (() => {
         const seoService = inject(SeoService);
-        return () => {
-          seoService.init();
-        };
+        // Returned so Angular awaits it — init() primes the cached base config
+        // that store-managed routes need during their route guard.
+        return () => seoService.init();
       })();
       return initializerFn();
     }),

--- a/libs/blog/shared/util-seo/src/lib/services/route-seo-data.spec.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/route-seo-data.spec.ts
@@ -49,6 +49,21 @@ describe('interpretRouteSeo', () => {
     expect(result.applyJsonLd).toBe(true);
   });
 
+  it('defaults aboutOrganization to false', () => {
+    expect(
+      interpretRouteSeo({ seo: { jsonLd: 'WebPage' } }).aboutOrganization,
+    ).toBe(false);
+    expect(interpretRouteSeo({ seo: false }).aboutOrganization).toBe(false);
+    expect(interpretRouteSeo({}).aboutOrganization).toBe(false);
+  });
+
+  it('surfaces aboutOrganization for the homepage', () => {
+    const result = interpretRouteSeo({
+      seo: { title: 'seo.home', jsonLd: 'WebPage', aboutOrganization: true },
+    });
+    expect(result.aboutOrganization).toBe(true);
+  });
+
   it('surfaces route.data.title as the collection name', () => {
     const result = interpretRouteSeo({
       seo: { title: 'News', jsonLd: 'CollectionPage' },

--- a/libs/blog/shared/util-seo/src/lib/services/route-seo-data.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/route-seo-data.ts
@@ -18,6 +18,12 @@ export type RouteSeoData =
       autoHrefLang?: boolean;
       /** schema.org page type, or `false` to suppress JSON-LD entirely. */
       jsonLd?: WebPageType | false;
+      /**
+       * Bind the page entity to the Organization via schema.org `about`.
+       * Only meaningful for the homepage, which is the page *about* the
+       * organization; other pages are about their own topic.
+       */
+      aboutOrganization?: boolean;
     }
   | false;
 
@@ -34,6 +40,8 @@ export interface SeoRouteInterpretation {
   collectionTitle?: string;
   /** Emit hreflang alternates. */
   autoHrefLang: boolean;
+  /** Emit `about: { @id: …#organization }` on the page entity. */
+  aboutOrganization: boolean;
 }
 
 /**
@@ -45,7 +53,12 @@ export function interpretRouteSeo(routeData: Data): SeoRouteInterpretation {
   const seo = routeData?.['seo'] as RouteSeoData | undefined;
 
   if (seo === false) {
-    return { managedExternally: true, applyJsonLd: false, autoHrefLang: false };
+    return {
+      managedExternally: true,
+      applyJsonLd: false,
+      autoHrefLang: false,
+      aboutOrganization: false,
+    };
   }
 
   if (!seo) {
@@ -54,6 +67,7 @@ export function interpretRouteSeo(routeData: Data): SeoRouteInterpretation {
       managedExternally: false,
       applyJsonLd: false,
       autoHrefLang: false,
+      aboutOrganization: false,
     };
   }
 
@@ -69,5 +83,6 @@ export function interpretRouteSeo(routeData: Data): SeoRouteInterpretation {
     titleKey: seo.title,
     collectionTitle: routeData?.['title'] as string | undefined,
     autoHrefLang: !!seo.autoHrefLang,
+    aboutOrganization: !!seo.aboutOrganization,
   };
 }

--- a/libs/blog/shared/util-seo/src/lib/services/seo-meta-keys.spec.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo-meta-keys.spec.ts
@@ -1,0 +1,40 @@
+import { isNameScopedMetaTag, SEO_META_KEYS } from './seo-meta-keys';
+
+describe('isNameScopedMetaTag', () => {
+  it.each([
+    // Google reads these only from the `name` attribute.
+    { tag: SEO_META_KEYS.description },
+    { tag: SEO_META_KEYS.robots },
+    // The Twitter card spec defines name="twitter:*".
+    { tag: SEO_META_KEYS.twitterCard },
+    { tag: SEO_META_KEYS.twitterDescription },
+    { tag: SEO_META_KEYS.twitterImage },
+    { tag: SEO_META_KEYS.twitterURL },
+    { tag: 'twitter:title' },
+    { tag: `${SEO_META_KEYS.twitterMiscLabel}1` },
+    { tag: `${SEO_META_KEYS.twitterMiscData}2` },
+  ])('$tag is name-scoped', ({ tag }) => {
+    expect(isNameScopedMetaTag(tag)).toBe(true);
+  });
+
+  it.each([
+    // OpenGraph and its article:* namespace belong in `property`.
+    { tag: SEO_META_KEYS.ogDescription },
+    { tag: SEO_META_KEYS.ogType },
+    { tag: SEO_META_KEYS.ogURL },
+    { tag: SEO_META_KEYS.ogLocale },
+    { tag: SEO_META_KEYS.ogSiteName },
+    { tag: SEO_META_KEYS.ogImage },
+    { tag: SEO_META_KEYS.articlePublishedTime },
+    { tag: SEO_META_KEYS.articleModifiedTime },
+    { tag: SEO_META_KEYS.articlePublisher },
+    { tag: 'og:title' },
+  ])('$tag is property-scoped', ({ tag }) => {
+    expect(isNameScopedMetaTag(tag)).toBe(false);
+  });
+
+  it('does not treat og:description as a twitter tag', () => {
+    expect(isNameScopedMetaTag('og:description')).toBe(false);
+    expect(isNameScopedMetaTag('twitter:description')).toBe(true);
+  });
+});

--- a/libs/blog/shared/util-seo/src/lib/services/seo-meta-keys.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo-meta-keys.ts
@@ -24,6 +24,21 @@ export const SEO_META_KEYS = {
 export type SeoMetaKeys = keyof typeof SEO_META_KEYS;
 
 /**
+ * Tags that live in the `name` attribute rather than `property`.
+ *
+ * `property` is the OpenGraph/RDFa attribute — correct for `og:*` and the
+ * `article:*` OpenGraph namespace. Everything else here is `name`-scoped by its
+ * own spec, and crawlers ignore it under `property`: Google reads only
+ * `<meta name="description">` and `<meta name="robots">`, and the Twitter card
+ * spec defines `name="twitter:*"`.
+ */
+const NAME_SCOPED_TAGS: readonly string[] = ['description', 'robots'];
+
+export function isNameScopedMetaTag(tag: string): boolean {
+  return NAME_SCOPED_TAGS.includes(tag) || tag.startsWith('twitter:');
+}
+
+/**
  * Truly site-wide BASE tags — exactly the keys `SeoService.applyBaseSeo()`
  * reapplies (with constant values) on every navigation, including store-managed
  * routes. They are NEVER removed by `resetPageSeo()`. Page-level tags such as

--- a/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
+++ b/libs/blog/shared/util-seo/src/lib/services/seo.service.ts
@@ -2,7 +2,7 @@ import { DOCUMENT, inject, Injectable } from '@angular/core';
 import { Meta, MetaDefinition, Title } from '@angular/platform-browser';
 import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { TranslocoService } from '@jsverse/transloco';
-import { filter, map, switchMap } from 'rxjs';
+import { filter, firstValueFrom, map, switchMap } from 'rxjs';
 
 import { Author } from '@angular-love/blog/contracts/authors';
 import { AlLocalizeService } from '@angular-love/blog/i18n/util';
@@ -13,14 +13,18 @@ import {
 } from '@angular-love/contracts/articles';
 
 import {
+  BreadcrumbItem,
   buildBlogPosting,
+  buildBreadcrumbId,
   buildHomeBreadcrumb,
   buildOrganization,
   buildPageGraph,
   buildPerson,
   buildPersonId,
   buildWebPage,
+  buildWebPageId,
   buildWebSite,
+  normalizeSeoDescription,
   rewriteImageUrl,
   SchemaGraphEntity,
   serializeJsonLd,
@@ -29,6 +33,7 @@ import { SEO_CONFIG, SeoConfig } from '../tokens';
 
 import { interpretRouteSeo, SeoRouteInterpretation } from './route-seo-data';
 import {
+  isNameScopedMetaTag,
   PAGE_REMOVABLE_META_KEYS,
   SEO_META_KEYS,
   SeoMetaKeys,
@@ -54,7 +59,11 @@ export class SeoService {
   private _baseUrl = '';
   private _siteName = '';
 
-  init(): void {
+  /**
+   * Returns a promise the app initializer awaits, so the cached base config is
+   * in place before routing starts.
+   */
+  init(): Promise<void> {
     this._router.events
       .pipe(
         filter((event) => event instanceof NavigationEnd),
@@ -110,8 +119,30 @@ export class SeoService {
 
         if (seo.applyJsonLd) {
           const inLanguage = seoConfig.locale.split('_')[0];
-          this.setJsonLd(this._buildPageEntities(seo, inLanguage));
+          this.setJsonLd(
+            this._buildPageEntities(seo, {
+              inLanguage,
+              description: seoConfig.description,
+            }),
+          );
         }
+      });
+
+    // Store-managed routes apply their seo (including JSON-LD) during the
+    // awaited route guard, which runs BEFORE the first NavigationEnd — so the
+    // subscription above has not cached baseUrl/siteName yet. The graph's
+    // Organization + WebSite entities are built from those two fields, so
+    // without priming them here they serialize with an empty name and url on
+    // any direct load of an article or author page. Both values are
+    // language-independent, so the first emission is enough.
+    return firstValueFrom(this._seoConfig)
+      .then(({ baseUrl, siteName }) => {
+        this._baseUrl = baseUrl;
+        this._siteName = siteName;
+      })
+      .catch(() => {
+        // Never fail app bootstrap over seo config; NavigationEnd still
+        // populates these for centrally-managed routes.
       });
   }
 
@@ -256,7 +287,19 @@ export class SeoService {
     const { baseUrl, lang } = opts;
     const pageUrl = `${baseUrl}${buildArticlePath(article.slug, lang)}`;
 
-    this.setMeta(article.seo, pageUrl);
+    this.setMeta(
+      {
+        ...article.seo,
+        // Yoast's per-post description is never filled in, so seo.description is
+        // the site-wide default (and in the site's language, not the article's).
+        // The article's own excerpt is the only per-article summary we have.
+        description: normalizeSeoDescription(article.excerpt),
+        // Same fallback as the JSON-LD datePublished — see buildBlogPosting.
+        article_published_time:
+          article.seo.article_published_time || article.publishDate,
+      },
+      pageUrl,
+    );
     this.setTitle(article.seo.title);
 
     const hreflangEntries = buildArticleHreflangEntries(article, baseUrl);
@@ -270,9 +313,9 @@ export class SeoService {
   }
 
   /**
-   * Build and inject the full article JSON-LD graph (BlogPosting + Person +
-   * BreadcrumbList).  pageUrl and baseUrl are passed explicitly so callers
-   * are not gated behind NavigationEnd timing.
+   * Build and inject the full article JSON-LD graph (WebPage + BlogPosting +
+   * Person + BreadcrumbList).  pageUrl and baseUrl are passed explicitly so
+   * callers are not gated behind NavigationEnd timing.
    */
   setArticleJsonLd(
     article: Article,
@@ -290,13 +333,30 @@ export class SeoService {
 
     // TODO: Article contract has no category field; breadcrumb is (Home → Article).
     //       Extend Article type with category info to add a middle Category item.
+    const breadcrumbId = buildBreadcrumbId(pageUrl);
     const breadcrumb = buildHomeBreadcrumb(
-      `${pageUrl}#breadcrumb`,
+      breadcrumbId,
       { name: article.title, url: pageUrl },
-      baseUrl,
+      this._homeCrumb(baseUrl, inLanguage),
     );
 
-    this.setJsonLd([blogPosting, person, breadcrumb]);
+    // The page entity the BlogPosting's mainEntityOfPage resolves to, and the
+    // owner of the breadcrumb — without it both would be dangling references.
+    const webPage = buildWebPage(
+      'WebPage',
+      buildWebPageId(pageUrl),
+      pageUrl,
+      article.title,
+      inLanguage,
+      baseUrl,
+      {
+        description: normalizeSeoDescription(article.excerpt),
+        mainEntity: { '@id': blogPosting['@id'] },
+        breadcrumb: { '@id': breadcrumbId },
+      },
+    );
+
+    this.setJsonLd([webPage, blogPosting, person, breadcrumb]);
   }
 
   /**
@@ -324,20 +384,25 @@ export class SeoService {
     }));
     this.setHreflang(hreflangEntries);
 
+    const breadcrumbId = buildBreadcrumbId(pageUrl);
     const profilePage = buildWebPage(
       'ProfilePage',
-      `${pageUrl}#webpage`,
+      buildWebPageId(pageUrl),
       pageUrl,
       author.name,
       lang,
       baseUrl,
-      { '@id': buildPersonId(author.slug, baseUrl) },
+      {
+        mainEntity: { '@id': buildPersonId(author.slug, baseUrl) },
+        description: bio,
+        breadcrumb: { '@id': breadcrumbId },
+      },
     );
     const person = buildPerson(author, { baseUrl });
     const breadcrumb = buildHomeBreadcrumb(
-      `${pageUrl}#breadcrumb`,
+      breadcrumbId,
       { name: author.name, url: pageUrl },
-      baseUrl,
+      this._homeCrumb(baseUrl, lang),
     );
     this.setJsonLd([profilePage, person, breadcrumb]);
   }
@@ -368,7 +433,7 @@ export class SeoService {
    */
   private _buildPageEntities(
     seo: SeoRouteInterpretation,
-    inLanguage: string,
+    ctx: { inLanguage: string; description: string },
   ): SchemaGraphEntity[] {
     if (!seo.jsonLdType) {
       return [];
@@ -379,8 +444,26 @@ export class SeoService {
       url: this._url,
       baseUrl: this._baseUrl,
       name: this._resolvePageName(seo),
-      inLanguage,
+      inLanguage: ctx.inLanguage,
+      // Mirrors the meta description applied for this page above.
+      description: ctx.description,
+      aboutOrganization: seo.aboutOrganization,
+      home: this._homeCrumb(this._baseUrl, ctx.inLanguage),
     });
+  }
+
+  /**
+   * Root breadcrumb crumb for the given language. `localizeExplicitPath` is the
+   * same helper that builds hreflang, so the url matches that language's
+   * homepage canonical exactly ('/' for en, '/pl' for pl).
+   */
+  private _homeCrumb(baseUrl: string, lang: string): BreadcrumbItem {
+    return {
+      // Translated in `lang` explicitly rather than the active language: this
+      // runs during the route guard, where the two can still differ.
+      name: this._translocoService.translate('seo.breadcrumbHome', {}, lang),
+      url: `${baseUrl}${this._localizeService.localizeExplicitPath('/', lang)}`,
+    };
   }
 
   private _resolvePageName(seo: SeoRouteInterpretation): string {
@@ -396,18 +479,18 @@ export class SeoService {
     const entries = Object.entries(miscData);
 
     for (const [index, entry] of entries.entries()) {
-      const label: MetaDefinition = {
-        property: `${SEO_META_KEYS.twitterMiscLabel}${index + 1}`,
-        content: entry[0],
-      };
-
-      const data: MetaDefinition = {
-        property: `${SEO_META_KEYS.twitterMiscData}${index + 1}`,
-        content: entry[1],
-      };
-
-      this._meta.updateTag(label);
-      this._meta.updateTag(data);
+      this._meta.updateTag(
+        buildMetaDefinition(
+          `${SEO_META_KEYS.twitterMiscLabel}${index + 1}`,
+          entry[0],
+        ),
+      );
+      this._meta.updateTag(
+        buildMetaDefinition(
+          `${SEO_META_KEYS.twitterMiscData}${index + 1}`,
+          entry[1],
+        ),
+      );
     }
   }
 
@@ -444,14 +527,11 @@ export class SeoService {
   }
 
   private updateTag(content: string, name: SeoMetaKeys | SeoTitleKeys): void {
-    const meta: MetaDefinition = {
-      property:
-        SEO_META_KEYS[name as SeoMetaKeys] ||
-        SEO_TITLE_KEYS[name as SeoTitleKeys],
-      content: content,
-    };
+    const tag =
+      SEO_META_KEYS[name as SeoMetaKeys] ||
+      SEO_TITLE_KEYS[name as SeoTitleKeys];
 
-    this._meta.updateTag(meta);
+    this._meta.updateTag(buildMetaDefinition(tag, content));
   }
 
   /**
@@ -559,6 +639,20 @@ export class SeoService {
     const pathname = _url.pathname.replace(/\/$/, '');
     return `${_url.origin}${pathname}`;
   }
+}
+
+/**
+ * Put the tag in the attribute its spec actually defines. Angular's `Meta`
+ * derives its lookup selector from whichever of `name`/`property` is set, so
+ * this also keeps updates and removals matching the tag that was written.
+ */
+export function buildMetaDefinition(
+  tag: string,
+  content: string,
+): MetaDefinition {
+  return isNameScopedMetaTag(tag)
+    ? { name: tag, content }
+    : { property: tag, content };
 }
 
 export function buildArticlePath(slug: string, langCode: string): string {

--- a/libs/blog/shell/feature-shell-web/src/lib/blog-shell.routes.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/blog-shell.routes.ts
@@ -33,7 +33,12 @@ export const commonRoutes: Route[] = [
           (await import('@angular-love/blog/home/feature-home'))
             .HomePageComponent,
         data: {
-          seo: { title: 'seo.home', autoHrefLang: true } satisfies RouteSeoData,
+          seo: {
+            title: 'seo.home',
+            autoHrefLang: true,
+            jsonLd: 'WebPage',
+            aboutOrganization: true,
+          } satisfies RouteSeoData,
         },
       },
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **SEO Improvements**
  * Enhanced homepage structured data with organization and breadcrumb links.
  * Improved JSON-LD descriptions using clean article excerpts and refined publication dates.
  * Corrected meta tag handling for social media previews.
* **API & Content**
  * Article detail endpoints now return excerpts.
  * Improved article publication date accuracy.
* **Localization**
  * Added localized homepage breadcrumb labels in English and Polish.
* **Tests**
  * Expanded coverage for SEO descriptions, structured data, dates, and route metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->