### PR TITLE
fix: update text in no-translation-dialog

### DIFF
--- a/apps/blog-analog/src/app/i18n/assets/en.json
+++ b/apps/blog-analog/src/app/i18n/assets/en.json
@@ -41,9 +41,9 @@
       "select_lang": "Select language",
       "noTranslationDialog": {
         "title": "Translation not available",
-        "description": "This article hasn't been translated into {{lang}} yet.",
+        "description": "This article is available only in English. Unfortunately, you can’t read it in Polish. On the Polish version of the blog, you will find many other useful resources.",
         "stayButton": "Stay on this page",
-        "goHomeButton": "Go to homepage"
+        "goHomeButton": "Go to Homepage"
       }
     }
   },

--- a/apps/blog-analog/src/app/i18n/assets/pl.json
+++ b/apps/blog-analog/src/app/i18n/assets/pl.json
@@ -41,7 +41,7 @@
       "select_lang": "Wybierz język",
       "noTranslationDialog": {
         "title": "Tłumaczenie niedostępne",
-        "description": "Ten artykuł nie jest jeszcze dostępny w tym języku.",
+        "description": "Ten artykuł jest dostępny wyłącznie w języku polskim. Niestety, nie możesz przeczytać go w języku angielskim. W angielskiej wersji bloga znajdziesz wiele innych przydatnych materiałów.",
         "stayButton": "Zostań na tej stronie",
         "goHomeButton": "Strona główna"
       }

--- a/apps/blog/src/assets/i18n/en.json
+++ b/apps/blog/src/assets/i18n/en.json
@@ -41,9 +41,9 @@
       "select_lang": "Select language",
       "noTranslationDialog": {
         "title": "Translation not available",
-        "description": "This article hasn't been translated into {{lang}} yet.",
+        "description": "This article is available only in English. Unfortunately, you can’t read it in Polish. On the Polish version of the blog, you will find many other useful resources.",
         "stayButton": "Stay on this page",
-        "goHomeButton": "Go to homepage"
+        "goHomeButton": "Go to Homepage"
       }
     }
   },

--- a/apps/blog/src/assets/i18n/pl.json
+++ b/apps/blog/src/assets/i18n/pl.json
@@ -41,7 +41,7 @@
       "select_lang": "Wybierz język",
       "noTranslationDialog": {
         "title": "Tłumaczenie niedostępne",
-        "description": "Ten artykuł nie jest jeszcze dostępny w tym języku.",
+        "description": "Ten artykuł jest dostępny wyłącznie w języku polskim. Niestety, nie możesz przeczytać go w języku angielskim. W angielskiej wersji bloga znajdziesz wiele innych przydatnych materiałów.",
         "stayButton": "Zostań na tej stronie",
         "goHomeButton": "Strona główna"
       }

--- a/libs/blog/shared/ui-button/src/lib/button/button.component.ts
+++ b/libs/blog/shared/ui-button/src/lib/button/button.component.ts
@@ -22,12 +22,12 @@ const buttonVariants = cva(
   {
     variants: {
       variant: <Record<AlButtonVariant, string>>{
-        Primary: 'bg-al-primary/90 text-white uppercase',
+        Primary: 'bg-al-primary/90 text-white',
         Secondary: 'bg-al-background border',
         Outline: 'border border-al-primary/90 bg-white text-al-primary',
         Ghost: 'bg-transparent',
         link: 'bg-transparent underline!',
-        AI: 'al-btn-ai font-semibold tracking-[0.12em] uppercase',
+        AI: 'al-btn-ai font-semibold tracking-[0.12em]',
       },
       size: <Record<AlButtonSize, string>>{
         small: 'py-2 px-4 text-xs',
@@ -41,6 +41,11 @@ const buttonVariants = cva(
     },
   },
 );
+
+const UPPERCASE_BY_DEFAULT: ReadonlySet<AlButtonVariant> = new Set([
+  'Primary',
+  'AI',
+]);
 
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
@@ -56,10 +61,20 @@ export class ButtonComponent {
 
   readonly size = input<AlButtonSize>();
 
+  // Overrides the variant's default text case
+  readonly uppercase = input<boolean>();
+
   protected class = computed(() => {
-    return buttonVariants({
-      variant: this.variant(),
-      size: this.size(),
-    });
+    const variant = this.variant() ?? 'Primary';
+    const isUppercase =
+      this.uppercase() ?? UPPERCASE_BY_DEFAULT.has(variant);
+
+    return cn(
+      buttonVariants({
+        variant,
+        size: this.size(),
+      }),
+      isUppercase && 'uppercase',
+    );
   });
 }

--- a/libs/blog/shell/feature-shell-web/src/lib/article-no-translation-dialog.component.ts
+++ b/libs/blog/shell/feature-shell-web/src/lib/article-no-translation-dialog.component.ts
@@ -21,13 +21,13 @@ export type ArticleNoTranslationDialogResult = 'home' | null;
     >
       <h2 class="text-xl font-bold">{{ t('title') }}</h2>
       <p class="text-al-muted-foreground">
-        {{ t('description', { lang: data.targetLangName }) }}
+        {{ t('description') }}
       </p>
       <div class="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
         <button al-button (click)="close(null)" variant="Secondary">
           {{ t('stayButton') }}
         </button>
-        <button al-button (click)="close('home')">
+        <button al-button (click)="close('home')" [uppercase]="false">
           {{ t('goHomeButton') }}
         </button>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added control over automatic uppercase styling for buttons, allowing labels such as “Go to Homepage” to retain their intended capitalization.

- **Improvements**
  - Updated unavailable-translation dialogs with clearer language-specific messaging.
  - English articles are identified as available only in English, while Polish articles are identified as available only in Polish.
  - Polish messaging now directs readers to additional useful content on the English blog.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->